### PR TITLE
fix bug where `uSIZE` is emited

### DIFF
--- a/typic-derive/src/lib.rs
+++ b/typic-derive/src/lib.rs
@@ -137,7 +137,7 @@ fn enum_repr(args: syn::AttributeArgs) -> (TokenStream2, String) {
   if let Some((repr, string)) = explicit {
     (quote!{#repr}, string)
   } else {
-    (quote!{isize}, "USIZE".to_string())
+    (quote!{isize}, "usize".to_string())
   }
 }
 


### PR DESCRIPTION
```rust
#[typic::repr(C)]
enum OptionLike {
    Bool(bool),
    Empty
}
```
This currently emits `uSIZE` due to a bug