### PR TITLE
Revamp transparency & safety parameters.

### DIFF
--- a/typic-derive/src/lib.rs
+++ b/typic-derive/src/lib.rs
@@ -23,12 +23,12 @@ pub fn stable_abi(input: TokenStream) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     (quote! {
-        impl #impl_generics typic::stability::Bound<typic::stability::Upper>
+        impl #impl_generics typic::stability::TransmutableFrom
         for #ident #ty_generics #where_clause
         {
             type Type = Self;
         }
-        impl #impl_generics typic::stability::Bound<typic::stability::Lower>
+        impl #impl_generics typic::stability::TransmutableInto
         for #ident #ty_generics #where_clause
         {
             type Type = Self;

--- a/typic-derive/src/lib.rs
+++ b/typic-derive/src/lib.rs
@@ -23,12 +23,13 @@ pub fn stable_abi(input: TokenStream) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     (quote! {
-        impl #impl_generics typic::stability::TransmutableFrom
+        unsafe impl #impl_generics typic::stability::TransmutableFrom
         for #ident #ty_generics #where_clause
         {
             type Type = Self;
         }
-        impl #impl_generics typic::stability::TransmutableInto
+
+        unsafe impl #impl_generics typic::stability::TransmutableInto
         for #ident #ty_generics #where_clause
         {
             type Type = Self;

--- a/typic-derive/src/lib.rs
+++ b/typic-derive/src/lib.rs
@@ -23,35 +23,17 @@ pub fn stable_abi(input: TokenStream) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     (quote! {
-        impl #impl_generics typic::stability::Never<
-          typic::stability::Increase,
-          typic::stability::Alignment,
-        > for #ident #ty_generics #where_clause {}
-
-        impl #impl_generics typic::stability::Never<
-          typic::stability::Decrease,
-          typic::stability::Alignment,
-        > for #ident #ty_generics #where_clause {}
-
-        impl #impl_generics typic::stability::Never<
-          typic::stability::Increase,
-          typic::stability::Size,
-        > for #ident #ty_generics #where_clause {}
-
-        impl #impl_generics typic::stability::Never<
-          typic::stability::Decrease,
-          typic::stability::Size,
-        > for #ident #ty_generics #where_clause {}
-
-        impl #impl_generics typic::stability::Never<
-          typic::stability::Increase,
-          typic::stability::Validity,
-        > for #ident #ty_generics #where_clause {}
-
-        impl #impl_generics typic::stability::Never<
-          typic::stability::Decrease,
-          typic::stability::Validity,
-        > for #ident #ty_generics #where_clause {}
+        impl #impl_generics typic::stability::Bound<typic::stability::Upper>
+        for #ident #ty_generics #where_clause
+        {
+            type Type = Self;
+        }
+        impl #impl_generics typic::stability::Bound<typic::stability::Lower>
+        for #ident #ty_generics #where_clause
+        {
+            type Type = Self;
+        }
+    
     }).into()
 }
 

--- a/typic-derive/src/lib.rs
+++ b/typic-derive/src/lib.rs
@@ -23,7 +23,35 @@ pub fn stable_abi(input: TokenStream) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     (quote! {
-        impl #impl_generics typic::StableABI for #ident #ty_generics #where_clause {}
+        impl #impl_generics typic::stability::Never<
+          typic::stability::Increase,
+          typic::stability::Alignment,
+        > for #ident #ty_generics #where_clause {}
+
+        impl #impl_generics typic::stability::Never<
+          typic::stability::Decrease,
+          typic::stability::Alignment,
+        > for #ident #ty_generics #where_clause {}
+
+        impl #impl_generics typic::stability::Never<
+          typic::stability::Increase,
+          typic::stability::Size,
+        > for #ident #ty_generics #where_clause {}
+
+        impl #impl_generics typic::stability::Never<
+          typic::stability::Decrease,
+          typic::stability::Size,
+        > for #ident #ty_generics #where_clause {}
+
+        impl #impl_generics typic::stability::Never<
+          typic::stability::Increase,
+          typic::stability::Validity,
+        > for #ident #ty_generics #where_clause {}
+
+        impl #impl_generics typic::stability::Never<
+          typic::stability::Decrease,
+          typic::stability::Validity,
+        > for #ident #ty_generics #where_clause {}
     }).into()
 }
 

--- a/typic/src/lib.rs
+++ b/typic/src/lib.rs
@@ -7,7 +7,7 @@
 //! Just import it and replace your `#[repr(...)]` attributes with `#[typic::repr(...)]`:
 //! ```
 //! // Import it!
-//! use typic::{self, transmute::StableTransmuteInto, StableABI};
+//! use typic::{self, transmute::StableTransmuteInto, stability::StableABI};
 //!
 //! // Update your attributes!
 //! #[typic::repr(C)]
@@ -32,7 +32,7 @@
 pub mod docs {
     pub mod prelude {
         use crate::typic;
-        pub use crate::StableABI;
+        pub use crate::stability::StableABI;
         pub use crate::transmute::{unsafe_transmute, StableTransmuteInto};
         pub use core::mem;
         pub use core::num::NonZeroU8;
@@ -97,9 +97,6 @@ pub use private::highlevel as internal;
 #[doc(inline)]
 pub use typic_derive::repr;
 
-#[deprecated(note = "To be removed.")]
-pub use typic_derive::StableABI;
-
 #[doc(inline)]
 pub use private::stability;
 
@@ -109,29 +106,6 @@ pub mod transmute;
 mod typic {
     pub use super::*;
 }
-
-/// A marker trait indicating that a type's in-memory layout is a guaranteed
-/// part of its API.
-///
-/// By implementing this trait for a type, it is a breaking change to do any
-/// of the following:
-/// 1. change its minimum alignment,
-/// 2. change its size, or
-/// 3. change the arrangement or validity of its fields.
-///
-/// ## Example
-/// ```rust
-/// # use typic::docs::prelude::*;
-/// # use core::mem;
-/// #[typic::repr(C)]
-/// #[derive(Default)]
-/// struct Foo_v1_0_0(pub u8, pub u16, pub u8);
-///
-/// assert_eq!(2, mem::align_of::<Foo_v1_0_0>());
-/// assert_eq!(6, mem::size_of::<Foo_v1_0_0>());
-/// ```
-#[deprecated(note = "To be removed.")]
-pub trait StableABI {}
 
 /// Details about the layout of types.
 ///

--- a/typic/src/lib.rs
+++ b/typic/src/lib.rs
@@ -25,8 +25,8 @@
 //! let _ : u32 = Foo(16, 12).transmute_into(); // Compile Error!
 //! ```
 //!
-//! [soundness]: crate::sound#when-is-a-transmutation-sound
-//! [safety]: crate::safe
+//! [soundness]: crate::transmute::unsafe_transmutation#when-is-a-transmutation-sound
+//! [safety]: crate::transmute::safe_transmutation
 
 #[doc(hidden)]
 pub mod docs {

--- a/typic/src/lib.rs
+++ b/typic/src/lib.rs
@@ -7,7 +7,7 @@
 //! Just import it and replace your `#[repr(...)]` attributes with `#[typic::repr(...)]`:
 //! ```
 //! // Import it!
-//! use typic::{self, StableTransmuteInto, StableABI};
+//! use typic::{self, transmute::StableTransmuteInto, StableABI};
 //!
 //! // Update your attributes!
 //! #[typic::repr(C)]
@@ -27,55 +27,13 @@
 //!
 //! [soundness]: crate::sound#when-is-a-transmutation-sound
 //! [safety]: crate::safe
-//!
-//! ## Three Types of Transmutation
-//!
-//! ### Unsound Transmutation
-//! [`transmute`]: core::mem::transmute
-//! [`transmute_copy`]: core::mem::transmute_copy
-//!
-//! The [`transmute`] and [`transmute_copy`] intrinsics
-//! allow for the ***unsafe*** and ***unsound*** transmutation between any `T`
-//! and `U`.
-//!
-//! These intrinsics are deeply unsafe. The Rust compiler will accept uses of
-//! these intrinsics even when `T` and `U` do not have well-defined layouts.
-//! ***Always use a [safe transmutation](#safe-transmutation) method instead,
-//! if possible.*** If you are unable to use a safe transmutation method,
-//! ***you may be relying on undefined compiler behavior***.
-//!
-//! ### Sound Transmutation
-//! [`transmute_sound`]: crate::transmute_sound
-//!
-//! The [`transmute_sound`] function allows for the ***unsafe*** transmutation
-//! between `T` and `U`, when merely transmuting from `T` to `U` will not cause
-//! undefined behavior. For the key rules that govern when `T` is soundly
-//! convertible to `U`, see ***[When is a transmutation sound?][soundness]***.
-//!
-//! This operation is `unsafe`, as it will bypass any user-defined validity
-//! restrictions that `U` places on its fields and enforces with its
-//! constructors and methods.
-//!
-//! ***Always use a [safe transmutation](#safe-transmutation) method instead, if
-//! possible.*** If you are unable to use a safe transmutation method, you may
-//! be violating library invariants.
-//!
-//! ### Safe Transmutation
-//! [safe transmutation]: #safe-transmutation
-//! [`TransmuteInto<U>`]: crate::TransmuteInto
-//!
-//! The [`TransmuteInto<U>`] trait is implemented for a type `T` if:
-//! 1. [`T` is ***soundly*** transmutable into `U`][soundness], and
-//! 2. [`T` is ***safely*** transmutable into `U`][safety].
-//!
-//! If you are unable to use [`TransmuteInto<U>`], you may be attempting a
-//! transmutation that is relying unspecified behavior.
+
 #[doc(hidden)]
 pub mod docs {
     pub mod prelude {
         use crate::typic;
         pub use crate::StableABI;
-        pub use crate::{transmute_sound, StableTransmuteInto};
+        pub use crate::transmute::{unsafe_transmute, StableTransmuteInto};
         pub use core::mem;
         pub use core::num::NonZeroU8;
 
@@ -127,6 +85,7 @@ pub mod private {
     pub mod highlevel;
     pub mod layout;
     pub mod num;
+    pub mod stability;
     pub mod target;
     pub mod transmute;
 }
@@ -134,338 +93,45 @@ pub mod private {
 #[doc(hidden)]
 pub use private::highlevel as internal;
 
-#[doc(inline)]
-pub use private::transmute::{transmute_safe, transmute_sound, TransmuteFrom, TransmuteInto, StableTransmuteInto};
-
 /// Use `#[typic::repr(...)]` instead of `#[repr(...)]` on your type definitions.
 #[doc(inline)]
-pub use typic_derive::{repr, StableABI};
+pub use typic_derive::repr;
+
+#[deprecated(note = "To be removed.")]
+pub use typic_derive::StableABI;
+
+#[doc(inline)]
+pub use private::stability;
+
+pub mod transmute;
+
 
 mod typic {
     pub use super::*;
 }
 
-pub mod neglect {
-    #[doc(inline)]
-    pub use crate::private::transmute::neglect::*;
-}
-
+/// A marker trait indicating that a type's in-memory layout is a guaranteed
+/// part of its API.
+///
+/// By implementing this trait for a type, it is a breaking change to do any
+/// of the following:
+/// 1. change its minimum alignment,
+/// 2. change its size, or
+/// 3. change the arrangement or validity of its fields.
+///
+/// ## Example
+/// ```rust
+/// # use typic::docs::prelude::*;
+/// # use core::mem;
+/// #[typic::repr(C)]
+/// #[derive(Default)]
+/// struct Foo_v1_0_0(pub u8, pub u16, pub u8);
+///
+/// assert_eq!(2, mem::align_of::<Foo_v1_0_0>());
+/// assert_eq!(6, mem::size_of::<Foo_v1_0_0>());
+/// ```
+#[deprecated(note = "To be removed.")]
 pub trait StableABI {}
-
-/// Guidance and tools for ***safe*** transmutation.
-///
-/// A [sound transmutation] is safe only if the resulting value cannot possibly
-/// violate library-enforced invariants. Typic assumes that all non-zero-sized
-/// fields with any visibility besides `pub` could have library-enforced
-/// invariants.
-///
-/// [sound transmutation]: crate#sound-transmutation
-/// [soundness]: crate::sound#when-is-a-transmutation-sound
-/// [`TransmuteInto`]: crate::TransmuteInto
-/// [`transmute_sound`]: crate::transmute_sound
-///
-/// ## Why is safety different than soundness?
-/// Consider the type `Constrained`, which enforces a validity constraint on its
-/// fields, and the type `Unconstrained` (which has no internal validity
-/// constraints):
-///
-/// ```
-/// # use typic::docs::prelude::*;
-/// #[typic::repr(C)]
-/// #[derive(StableABI)]
-/// pub struct Constrained {
-///     wizz: i8,
-///     bang: u8,
-/// }
-///
-/// impl Constrained {
-///     /// the sum of `wizz` and `bang` must be greater than or equal to zero.
-///     pub fn new(wizz: i8, bang: u8) -> Self {
-///         assert!((wizz as i16) / (bang as i16) >= 0);
-///         Constrained { wizz, bang }
-///     }
-///
-///     pub fn something_dangerous(&self) {
-///         unsafe {
-///             // do something that's only safe if `wizz + bang >= 0`
-///         }
-///     }
-/// }
-///
-/// #[typic::repr(C)]
-/// #[derive(StableABI)]
-/// pub struct Unconstrained {
-///     pub wizz: u8,
-///     pub bang: i8,
-/// }
-/// ```
-///
-/// It is [sound][soundness] to transmute an instance of `Unconstrained` into
-/// `Constrained`:
-/// ```
-/// use typic::docs::prelude::*;
-/// use typic::neglect;
-/// let _ : Constrained  = unsafe { transmute_sound::<_, _, neglect::Transparency>(Unconstrained::default()) };
-/// ```
-/// ...but it is **not** safe! The [`transmute_sound`] function creates an
-/// instance of `Bar` _without_ calling its `new` constructor, thereby bypassing
-/// the safety check which ensures `something_dangerous` does not violate Rust's
-/// memory model. The compiler will reject our program if we try to safely
-/// transmute `Unconstrained` to `Constrained`:
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// let unconstrained = Unconstrained::default();
-/// let _ : Constrained  = unconstrained.transmute_into();
-/// ```
-///
-/// Or, ***automatically***, by marking the fields `pub`:
-/// ```
-/// # use typic::docs::prelude::*;
-/// #[typic::repr(C)]
-/// #[derive(StableABI)]
-/// pub struct Unconstrained {
-///     pub wizz: u8,
-///     pub bang: i8,
-/// }
-///
-/// let _ : Unconstrained = u16::default().transmute_into();
-/// ```
-///
-/// If the fields are marked `pub`, the type cannot possibly rely on any
-/// internal validity requirements, as users of the type are free to manipulate
-/// its fields direclty via the `.` operator.
-///
-/// ## Safely transmuting references
-/// When safely transmuting owned values, all non-padding bytes in the source
-/// type must correspond to `pub` bytes in the destination type:
-/// ```
-/// # use typic::docs::prelude::*;
-/// let _ : Unconstrained = Constrained::default().transmute_into();
-/// ```
-/// The visibility (or lack thereof) of bytes in the source type does not
-/// affect safety.
-///
-/// When safely transmuting references, each corresponding byte in the source
-/// and destination types must have the _same_ visibility. Without this
-/// restriction, you could inadvertently violate library invariants of a type
-/// by transmuting and mutating a mutable reference to it:
-///
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// let mut x = Constrained::default();
-///
-/// {
-///     let y : &mut Unconstrained = (&mut x).transmute_into();
-///                                        // ^^^^^^^^^^^^^^
-///                                        // Compile Error!
-///     let z : u8 = -100i8.transmute_into();
-///     y.wizz = z;
-/// }
-///
-/// // Ack! `x.wizz + x.bang` is now -100!
-/// // This violates the safety invariant of `something_dangerous`!
-/// x.something_dangerous();
-/// ```
-pub mod safe {
-    #[doc(inline)]
-    pub use crate::{transmute_safe, TransmuteFrom, TransmuteInto, StableTransmuteInto};
-}
-
-/// Guidance and tools for ***sound*** transmutation.
-///
-/// A transmutation is ***sound*** if the mere act of transmutation is
-/// guaranteed to not violate Rust's memory model.
-///
-/// [`transmute_sound`]: crate::transmute_sound
-/// [`TransmuteInto<U>`]: crate::TransmuteInto
-///
-/// ## When is a transmutation sound?
-/// [`NonZeroU8`]: core::num::NonZeroU8
-///
-/// A transmutation is only sound if it occurs between types with [well-defined
-/// representations](#well-defined-representation), and does not violate Rust's
-/// memory model. See [*Transmutations Between Owned Values*][transmute-owned],
-/// and [*Transmutations Between References*][transmute-references]. These rules
-/// are automatically enforced by [`transmute_sound`] and [`TransmuteInto<U>`].
-///
-/// ### Well-Defined Representation
-/// [`u8`]: core::u8
-/// [`f32`]: core::f32
-///
-/// Transmutation is ***always unsound*** if it occurs between types with
-/// unspecified representations. Most of Rust's primitive types have specified
-/// representations. That is, the layout characteristics of [`u8`], [`f32`] and
-/// others are guaranteed to be stable across compiler versions.
-///
-/// In contrast, most `struct` and `enum` types defined without an explicit
-/// `#[repr(C)]` or `#[repr(transparent)]` attribute do ***not*** have
-/// well-specified layout characteristics.
-///
-/// To ensure that types you've define are soundly transmutable, you usually
-/// must mark them with the `#[repr(C)]` attribute.
-///
-/// ### Transmuting Owned Values
-/// [transmute-owned]: #transmuting-owned-values
-///
-/// Transmutations involving owned values must adhere to two rules to be sound.
-/// They must:
-///  * [preserve or broaden the bit validity][owned-validity], and
-///  * [preserve or shrink the size][owned-size].
-///
-/// #### Preserve or Broaden Bit Validity
-/// [owned-validity]: #preserve-or-broaden-bit-validity
-///
-/// For each _i<sup>th</sup>_ of the destination type, all possible
-/// instantiations of the _i<sup>th</sup>_ byte of the source type must be a
-/// bit-valid instance of the _i<sup>th</sup>_ byte of the destination type.
-///
-/// For example, we are permitted us to transmute a [`NonZeroU8`] into a [`u8`]:
-/// ```rust
-/// # use typic::docs::prelude::*;
-/// let _ : u8 = NonZeroU8::new(1).unwrap().transmute_into();
-/// ```
-/// ...because all possible instances of [`NonZeroU8`] are also valid instances
-/// of [`u8`]. However, transmuting a [`u8`] into a [`NonZeroU8`] is forbidden:
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// let _ : NonZeroU8 = u8::default().transmute_into(); // Compile Error!
-/// ```
-/// ...because not all instances of [`u8`] are valid instances of [`NonZeroU8`].
-///
-/// Another example: While laying out certain types, rust may insert padding
-/// bytes between the layouts of fields. In the below example `Padded` has two
-/// padding bytes, while `Packed` has none:
-/// ```rust
-/// # use typic::docs::prelude::*;
-/// #[typic::repr(C)]
-/// #[derive(Default)]
-/// struct Padded(pub u8, pub u16, pub u8);
-///
-/// #[typic::repr(C)]
-/// #[derive(Default)]
-/// struct Packed(pub u16, pub u16, pub u16);
-///
-/// assert_eq!(mem::size_of::<Packed>(), mem::size_of::<Padded>());
-/// ```
-///
-/// We may safely transmute from `Packed` to `Padded`:
-/// ```rust
-/// # use typic::docs::prelude::*;
-/// let _ : Padded = Packed::default().transmute_into();
-/// ```
-/// ...but not from `Padded` to `Packed`:
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// let _ : Packed = Padded::default().transmute_into(); // Compile Error!
-/// ```
-/// ...because doing so would expose two uninitialized padding bytes in `Padded`
-/// as if they were initialized bytes in `Packed`.
-///
-/// #### Preserve or Shrink Size
-/// [owned-size]: #preserve-or-shrink-size
-///
-/// It's completely safe to transmute into a type with fewer bytes than the
-/// destination type; e.g.:
-/// ```rust
-/// # use typic::docs::prelude::*;
-/// let _ : u8 = u64::default().transmute_into();
-/// ```
-/// This transmute truncates away the final three bytes of the `u64` value.
-///
-/// A value may ***not*** be transmuted into a type of greater size:
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// let _ : u64 = u8::default().transmute_into(); // Compile Error!
-/// ```
-///
-/// ### Transmuting References
-/// [transmute-references]: #transmuting-references
-///
-/// The [restrictions above that to transmuting owned values][transmute-owned],
-/// also apply to transmuting references. However, references carry a few
-/// additional restrictions. A [sound transmutation](#sound-transmutation) must:
-///  - [preserve or relax alignment][reference-alignment],
-///  - [preserve or shrink lifetimes][reference-lifetimes],
-///  - [preserve or shrink mutability][reference-mutability], and
-///  - [preserve validity][reference-validity].
-///
-/// #### Preserve or Relax Alignment
-/// [reference-alignment]: #preserve-or-relax-alignment
-///
-/// You may transmute a reference into reference of more relaxed alignment:
-/// ```rust
-/// # use typic::docs::prelude::*;
-/// let _: &[u8; 0] = (&[0u16; 0]).transmute_into();
-/// ```
-///
-/// However, you may **not** transmute a reference into a reference of stricter
-/// alignment:
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// let _: &[u16; 0] = (&[0u8; 0]).transmute_into(); // Compile Error!
-/// ```
-///
-/// #### Preserve or Shrink Lifetimes
-/// [reference-lifetimes]: #preserve-or-shrink-lifetimes
-///
-/// You may transmute a reference into reference of lesser lifetime:
-/// ```rust
-/// # use typic::docs::prelude::*;
-/// fn shrink<'a>() -> &'a u8 {
-///     static long : &'static u8 =  &16;
-///     long
-/// }
-/// ```
-///
-/// However, you may **not** transmute a reference into a reference of greater
-/// lifetime:
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// fn extend<'a>(short: &'a u8) -> &'static u8 {
-///     static long : &'static u8 =  &16;
-///     short.transmute_into()
-/// }
-/// ```
-///
-/// #### Preserve or Shrink Mutability
-/// [reference-mutability]: #preserve-or-shrink-mutability
-///
-/// You may preserve or decrease the mutability of a reference through
-/// transmutation:
-/// ```rust
-/// # use typic::docs::prelude::*;
-/// let _: &u8 = (&42u8).transmute_into();
-/// let _: &u8 = (&mut 42u8).transmute_into();
-/// ```
-///
-/// However, you may **not** transmute an immutable reference into a mutable
-/// reference:
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// let _: &mut u8 = (&42u8).transmute_into(); // Compile Error!
-/// ```
-///
-/// #### Preserve Validity
-/// [reference-validity]: #preserve-validity
-///
-/// Unlike transmutations of owned values, the transmutation of a reference may
-/// also not expand the bit-validity of the referenced type. For instance:
-///
-/// ```compile_fail
-/// # use typic::docs::prelude::*;
-/// let mut x = NonZeroU8::new(42).unwrap();
-/// {
-///     let y : &mut u8 = (&mut x).transmute_into(); // Compile Error!
-///     *y = 0;
-/// }
-///
-/// let z : NonZeroU8 = x;
-/// ```
-/// If this example did not produce a compile error, the value of `z` would not
-/// be a bit-valid instance of its type.
-pub mod sound {
-    pub use crate::transmute_sound;
-}
 
 /// Details about the layout of types.
 ///
@@ -480,7 +146,7 @@ pub mod sound {
 /// [`Unaligned`] marker traits:
 ///
 /// ```
-/// use typic::{layout::{Layout, SizeOf}, TransmuteInto, TransmuteFrom};
+/// use typic::{layout::{Layout, SizeOf}, transmute::TransmuteInto, transmute::TransmuteFrom};
 /// use generic_array::{ArrayLength as Length, GenericArray as Array};
 /// use typenum::U1;
 /// 

--- a/typic/src/lib.rs
+++ b/typic/src/lib.rs
@@ -75,6 +75,7 @@ pub mod docs {
     }
 }
 
+
 #[doc(hidden)]
 #[deprecated(note = "TODO")]
 pub enum TODO {}
@@ -161,7 +162,7 @@ pub mod layout {
     use crate::internal::{Public, Private};
 
     /// Type-level information about type representation.
-    pub trait Layout {
+    pub trait Layout: layout::Layout<Public> {
         /// The size of `Self`.
         ///
         /// ```

--- a/typic/src/private/bytelevel.rs
+++ b/typic/src/private/bytelevel.rs
@@ -12,11 +12,11 @@ use crate::private::num::{Sub1, U1};
 use crate::private::target::PointerWidth;
 
 #[cfg(target_endian = "little")]
-pub type NonZeroSeq<S, Rest> =
-    PCons<slot::NonZeroSlot<U1>, PCons<slot::InitializedSlot<Sub1<S>>, Rest>>;
+pub type NonZeroSeq<Vis, S, Rest> =
+    PCons<slot::NonZeroSlot<Vis, U1>, PCons<slot::InitializedSlot<Vis, Sub1<S>>, Rest>>;
 
 #[cfg(target_endian = "big")]
-pub type NonZeroSeq<S, Rest> =
-    PCons<slot::InitializedSlot<Sub1<S>, PCons<slot::NonZeroSlot<U1>>, Rest>>;
+pub type NonZeroSeq<Vis, S, Rest> =
+    PCons<slot::InitializedSlot<Vis, Sub1<S>, PCons<slot::NonZeroSlot<Vis, U1>>, Rest>>;
 
-pub type ReferenceBytes<Rest> = NonZeroSeq<PointerWidth, Rest>;
+pub type ReferenceBytes<Vis, Rest> = NonZeroSeq<Vis, PointerWidth, Rest>;

--- a/typic/src/private/bytelevel/ops.rs
+++ b/typic/src/private/bytelevel/ops.rs
@@ -10,21 +10,21 @@ pub trait Add<RHS> {
 
 pub type Sum<A, B> = <A as Add<B>>::Output;
 
-impl<K> Add<PNil> for Bytes<K, num::UTerm> {
+impl<Vis, K> Add<PNil> for Bytes<Vis, K, num::UTerm> {
     type Output = PNil;
 }
 
 /// `Bytes<_, N> + PNil = Bytes<_, N>`, where `N > 0`.
-impl<K, A, B> Add<PNil> for Bytes<K, num::UInt<A, B>> {
+impl<Vis, K, A, B> Add<PNil> for Bytes<Vis, K, num::UInt<A, B>> {
     type Output = PCons<Self, PNil>;
 }
 
-impl<K, H, T> Add<PCons<H, T>> for Bytes<K, num::UTerm> {
+impl<Vis, K, H, T> Add<PCons<H, T>> for Bytes<Vis, K, num::UTerm> {
     type Output = PCons<H, T>;
 }
 
 /// `Bytes<_, N> + PNil = Bytes<_, N>`, where `N > 0`.
-impl<K, H, T, A, B> Add<PCons<H, T>> for Bytes<K, num::UInt<A, B>> {
+impl<Vis, K, H, T, A, B> Add<PCons<H, T>> for Bytes<Vis, K, num::UInt<A, B>> {
     type Output = PCons<Self, PCons<H, T>>;
 }
 

--- a/typic/src/private/bytelevel/slot.rs
+++ b/typic/src/private/bytelevel/slot.rs
@@ -6,6 +6,12 @@ pub use array::Array;
 pub use bytes::Bytes;
 pub use reference::{Reference, Shared, SharedRef, Unique, UniqueRef};
 
-pub type PaddingSlot<S> = Bytes<bytes::kind::Uninitialized, S>;
-pub type InitializedSlot<S> = Bytes<bytes::kind::Initialized, S>;
-pub type NonZeroSlot<S> = Bytes<bytes::kind::NonZero, S>;
+/// The data is from a `pub` field
+pub type Pub = crate::internal::Public;
+
+/// The field is from a field that is not `pub`. 
+pub type Priv = crate::internal::Private;
+
+pub type PaddingSlot<S> = Bytes<Pub, bytes::kind::Uninitialized, S>;
+pub type InitializedSlot<Vis, S> = Bytes<Vis, bytes::kind::Initialized, S>;
+pub type NonZeroSlot<Vis, S> = Bytes<Vis, bytes::kind::NonZero, S>;

--- a/typic/src/private/bytelevel/slot.rs
+++ b/typic/src/private/bytelevel/slot.rs
@@ -12,6 +12,6 @@ pub type Pub = crate::internal::Public;
 /// The field is from a field that is not `pub`. 
 pub type Priv = crate::internal::Private;
 
-pub type PaddingSlot<S> = Bytes<Pub, bytes::kind::Uninitialized, S>;
+pub type PaddingSlot<Vis, S> = Bytes<Vis, bytes::kind::Uninitialized, S>;
 pub type InitializedSlot<Vis, S> = Bytes<Vis, bytes::kind::Initialized, S>;
 pub type NonZeroSlot<Vis, S> = Bytes<Vis, bytes::kind::NonZero, S>;

--- a/typic/src/private/bytelevel/slot/array.rs
+++ b/typic/src/private/bytelevel/slot/array.rs
@@ -1,6 +1,5 @@
 //! [T; N]
-
 use core::marker::PhantomData;
 
 /// A unique reference to a type `T` with lifetime `'a`.
-pub struct Array<T, N>(PhantomData<(T, N)>);
+pub struct Array<Visibility, T, N>(PhantomData<(Visibility, T, N)>);

--- a/typic/src/private/bytelevel/slot/bytes.rs
+++ b/typic/src/private/bytelevel/slot/bytes.rs
@@ -1,9 +1,8 @@
 //! Non-reference slots.
-
 use core::marker::PhantomData;
 
 /// A sequence of bytes of `Kind` and `Size`.
-pub struct Bytes<Kind, Size>(PhantomData<(Kind, Size)>);
+pub struct Bytes<Vis, Kind, Size>(PhantomData<(Vis, Kind, Size)>);
 
 /// Markers indicating the kind of bit-level validity restrictions that exist
 /// on a `Bytes`.

--- a/typic/src/private/bytelevel/slot/reference.rs
+++ b/typic/src/private/bytelevel/slot/reference.rs
@@ -5,10 +5,10 @@ use core::marker::PhantomData;
 pub struct Shared;
 pub struct Unique;
 
-pub struct Reference<'a, K, T>(PhantomData<(K, &'a T)>);
+pub struct Reference<'a, Visibility, K, T>(PhantomData<(Visibility, K, &'a T)>);
 
 /// A unique reference to a type `T` with lifetime `'a`.
-pub type UniqueRef<'a, T> = Reference<'a, Unique, T>;
+pub type UniqueRef<'a, Visibility, T> = Reference<'a, Visibility, Unique, T>;
 
 /// A shared reference to a type `T` with lifetime `'a`.
-pub type SharedRef<'a, T> = Reference<'a, Shared, T>;
+pub type SharedRef<'a, Visibility, T> = Reference<'a, Visibility, Shared, T>;

--- a/typic/src/private/highlevel.rs
+++ b/typic/src/private/highlevel.rs
@@ -2,11 +2,15 @@
 
 pub mod coproduct;
 pub mod product;
+pub mod field;
 
 use crate::private::num::Unsigned;
 
 #[doc(hidden)]
 pub use typenum::consts::*;
+
+#[doc(inline)]
+pub use field::{Field, Public, Private};
 
 #[doc(inline)]
 pub use coproduct::{Cons as CCons, Nil as CNil};
@@ -31,42 +35,6 @@ pub trait Type {
     /// An abstract representation of the type's structure.
     type HighLevel;
 }
-
-/// Indicates a type has no internal validity requirements.
-///
-/// The `Transparent` trait is used to indicate that a compound type does not
-/// place any additional validity restrictions on its fields.
-///
-/// This trait can be implemented ***manually***:
-/// ```
-/// # use typic::docs::prelude::*;
-/// #[typic::repr(C)]
-/// pub struct Unconstrained {
-///     wizz: u8,
-///     bang: i8,
-/// }
-///
-/// unsafe impl Transparent for Unconstrained {}
-///
-/// let _ : Unconstrained = u16::default().transmute_into();
-/// ```
-///
-/// Or, ***automatically***, by marking the fields `pub`:
-/// ```
-/// # use typic::docs::prelude::*;
-/// #[typic::repr(C)]
-/// pub struct Unconstrained {
-///     pub wizz: u8,
-///     pub bang: i8,
-/// }
-///
-/// let _ : Unconstrained = u16::default().transmute_into();
-/// ```
-///
-/// If the fields are marked `pub`, the type cannot rely on any internal
-/// validity requirements, as users of the type are free to manipulate its
-/// fields via the `.` operator.
-pub unsafe trait Transparent: Type {}
 
 pub(crate) type HighLevelOf<T> = <T as Type>::HighLevel;
 pub(crate) type ReprAlignOf<T> = <T as Type>::ReprAlign;

--- a/typic/src/private/highlevel/field.rs
+++ b/typic/src/private/highlevel/field.rs
@@ -1,0 +1,27 @@
+use core::marker::PhantomData;
+use crate::private::num::Min;
+
+pub struct Public;
+pub struct Private;
+
+impl Min<Public> for Public {
+  type Output = Public;
+  fn min(self, rhs: Public) -> Self::Output {Public}
+}
+
+impl Min<Private> for Private {
+  type Output = Private;
+  fn min(self, rhs: Private) -> Self::Output {Private}
+}
+
+impl Min<Public> for Private {
+  type Output = Private;
+  fn min(self, rhs: Public) -> Self::Output {Private}
+}
+
+impl Min<Private> for Public {
+  type Output = Private;
+  fn min(self, rhs: Private) -> Self::Output {Private}
+}
+
+pub struct Field<Vis, Type>(PhantomData<(Vis, Type)>);

--- a/typic/src/private/layout.rs
+++ b/typic/src/private/layout.rs
@@ -9,9 +9,10 @@ mod padding;
 pub use aligned_to::AlignedTo;
 use into_bytelevel::IntoByteLevel;
 use padding::PaddingNeededForField;
+use crate::private::highlevel::Public;
 
 /// The actual memory layout characteristics of `Self`.
-pub trait Layout<Visibility> {
+pub trait Layout<Visibility=Public> {
     /// The actual alignment of `Self`.
     type Align: Unsigned;
 

--- a/typic/src/private/layout.rs
+++ b/typic/src/private/layout.rs
@@ -11,7 +11,7 @@ use into_bytelevel::IntoByteLevel;
 use padding::PaddingNeededForField;
 
 /// The actual memory layout characteristics of `Self`.
-pub trait Layout {
+pub trait Layout<Visibility> {
     /// The actual alignment of `Self`.
     type Align: Unsigned;
 
@@ -23,7 +23,7 @@ pub trait Layout {
 }
 
 #[rustfmt::skip]
-impl<T> Layout for T
+impl<T, Visibility> Layout<Visibility> for T
 where
     T: Type,
 
@@ -31,24 +31,28 @@ where
         IntoByteLevel<
             ReprAlignOf<T>,
             ReprPackedOf<T>,
+            Visibility,
         >,
 {
     type Align =
         <HighLevelOf<T> as IntoByteLevel<
             ReprAlignOf<T>,
             ReprPackedOf<T>,
+            Visibility,
         >>::Align;
 
     type Size =
         <HighLevelOf<T> as IntoByteLevel<
             ReprAlignOf<T>,
             ReprPackedOf<T>,
+            Visibility,
         >>::Offset;
 
     type ByteLevel =
         <HighLevelOf<T> as IntoByteLevel<
             ReprAlignOf<T>,
             ReprPackedOf<T>,
+            Visibility,
         >>::Output;
 }
 

--- a/typic/src/private/layout/aligned_to.rs
+++ b/typic/src/private/layout/aligned_to.rs
@@ -1,12 +1,13 @@
 use super::Layout;
 use crate::private::num::*;
+use crate::internal::Public;
 
 pub trait AlignedTo<T> {}
 
 impl<T, U> AlignedTo<T> for U
 where
-    T: Layout,
-    U: Layout,
-    <T as Layout>::Align: PartialDiv<<U as Layout>::Align>,
+    T: Layout<Public>,
+    U: Layout<Public>,
+    <T as Layout<Public>>::Align: PartialDiv<<U as Layout<Public>>::Align>,
 {
 }

--- a/typic/src/private/layout/into_bytelevel.rs
+++ b/typic/src/private/layout/into_bytelevel.rs
@@ -6,7 +6,7 @@ pub mod field;
 pub mod primitives;
 pub mod product;
 
-pub trait IntoByteLevel<ReprAlign, ReprPacked, Offset = U0> {
+pub trait IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset = U0> {
     /// The byte-level representation of the type.
     type Output;
 

--- a/typic/src/private/layout/into_bytelevel/field.rs
+++ b/typic/src/private/layout/into_bytelevel/field.rs
@@ -32,7 +32,7 @@ where
     num::Minimum<Packed, <F as Layout<Minimum<V, Visibility>>>::Align>: Unsigned,
 {
     type Output = PCons<
-        PaddingSlot<<F as PaddingNeededForField<Minimum<V, Visibility>, Offset, Packed>>::Output>,
+        PaddingSlot<Visibility, <F as PaddingNeededForField<Minimum<V, Visibility>, Offset, Packed>>::Output>,
         <F as Layout<Minimum<V, Visibility>>>::ByteLevel,
     >;
 

--- a/typic/src/private/layout/into_bytelevel/field.rs
+++ b/typic/src/private/layout/into_bytelevel/field.rs
@@ -1,8 +1,9 @@
 use crate::private::bytelevel::{slot::PaddingSlot, PCons};
 use crate::private::layout::{Layout, PaddingNeededForField};
-use crate::private::num::{self, Unsigned};
+use crate::private::num::{self, Minimum, Min, Unsigned};
+use crate::internal::Field;
 
-pub trait FieldIntoByteLevel<Packed, Offset> {
+pub trait FieldIntoByteLevel<Packed, Visibility, Offset> {
     /// The padded, byte-level representation of `Self`.
     type Output;
 
@@ -13,31 +14,32 @@ pub trait FieldIntoByteLevel<Packed, Offset> {
     type Align: Unsigned;
 }
 
-impl<Packed, Offset, F> FieldIntoByteLevel<Packed, Offset> for F
+impl<Packed, Visibility, Offset, V, F> FieldIntoByteLevel<Packed, Visibility, Offset> for Field<V, F>
 where
-    F: Layout + PaddingNeededForField<Offset, Packed>,
-    Offset: num::Add<<F as PaddingNeededForField<Offset, Packed>>::Output>,
+    F: Layout<Minimum<V, Visibility>> + PaddingNeededForField<Minimum<V, Visibility>, Offset, Packed>,
+    V: Min<Visibility>,
+    Offset: num::Add<<F as PaddingNeededForField<Minimum<V, Visibility>, Offset, Packed>>::Output>,
 
-    num::Sum<Offset, <F as PaddingNeededForField<Offset, Packed>>::Output>:
-      num::Add<<F as Layout>::Size>,
+    num::Sum<Offset, <F as PaddingNeededForField<Minimum<V, Visibility>, Offset, Packed>>::Output>:
+      num::Add<<F as Layout<Minimum<V, Visibility>>>::Size>,
 
     num::Sum<
-      num::Sum<Offset, <F as PaddingNeededForField<Offset, Packed>>::Output>,
-      <F as Layout>::Size
+      num::Sum<Offset, <F as PaddingNeededForField<Minimum<V, Visibility>, Offset, Packed>>::Output>,
+      <F as Layout<Minimum<V, Visibility>>>::Size
     >: Unsigned,
 
-    Packed: num::Min<<F as Layout>::Align>,
-    num::Minimum<Packed, <F as Layout>::Align>: Unsigned,
+    Packed: num::Min<<F as Layout<Minimum<V, Visibility>>>::Align>,
+    num::Minimum<Packed, <F as Layout<Minimum<V, Visibility>>>::Align>: Unsigned,
 {
     type Output = PCons<
-        PaddingSlot<<F as PaddingNeededForField<Offset, Packed>>::Output>,
-        <F as Layout>::ByteLevel,
+        PaddingSlot<<F as PaddingNeededForField<Minimum<V, Visibility>, Offset, Packed>>::Output>,
+        <F as Layout<Minimum<V, Visibility>>>::ByteLevel,
     >;
 
     type Offset = num::Sum<
-      num::Sum<Offset, <F as PaddingNeededForField<Offset, Packed>>::Output>,
-      <F as Layout>::Size
+      num::Sum<Offset, <F as PaddingNeededForField<Minimum<V, Visibility>, Offset, Packed>>::Output>,
+      <F as Layout<Minimum<V, Visibility>>>::Size
     >;
 
-    type Align = num::Minimum<Packed, <F as Layout>::Align>;
+    type Align = num::Minimum<Packed, <F as Layout<Minimum<V, Visibility>>>::Align>;
 }

--- a/typic/src/private/layout/into_bytelevel/primitives.rs
+++ b/typic/src/private/layout/into_bytelevel/primitives.rs
@@ -1,4 +1,3 @@
-use crate::StableABI;
 use crate::stability::*;
 use super::IntoByteLevel;
 use crate::private::bytelevel::{

--- a/typic/src/private/layout/into_bytelevel/primitives.rs
+++ b/typic/src/private/layout/into_bytelevel/primitives.rs
@@ -1,4 +1,5 @@
 use crate::StableABI;
+use crate::stability::*;
 use super::IntoByteLevel;
 use crate::private::bytelevel::{
     slot::{Array, InitializedSlot, SharedRef, UniqueRef},
@@ -20,7 +21,7 @@ macro_rules! primitive_layout {
                 #[doc(hidden)] type HighLevel = Self;
             }
 
-            impl StableABI for $ty {}
+            impl<D: Direction, A: Aspect> Never<D, A> for $ty {}
 
             impl<ReprAlign, ReprPacked, Visibility, Offset> IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset> for $ty
             where
@@ -76,7 +77,7 @@ macro_rules! nonzero_layout {
                 #[doc(hidden)] type HighLevel = Self;
             }
 
-            impl StableABI for $ty {}
+            impl<D: Direction, A: Aspect> Never<D, A> for $ty {}
 
             impl<ReprAlign, ReprPacked, Visibility, Offset> IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset> for $ty
             where
@@ -115,7 +116,7 @@ impl Type for () {
     #[doc(hidden)] type HighLevel = Self;
 }
 
-impl StableABI for () {}
+impl<D: Direction, A: Aspect> Never<D, A> for () {}
 
 impl<ReprAlign, ReprPacked, Visibility, Offset> IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset> for ()
 where
@@ -127,7 +128,7 @@ where
     type Align = PointerWidth;
 }
 
-impl<'a, T> StableABI for &'a T {}
+impl<'a, D: Direction, A: Aspect, T> Never<D, A> for &'a T {}
 
 #[rustfmt::skip]
 impl<'a, T> Type for &'a T {
@@ -146,7 +147,7 @@ where
     type Align = PointerWidth;
 }
 
-impl<'a, T> StableABI for &'a mut T {}
+impl<'a, D: Direction, A: Aspect, T> Never<D, A> for &'a mut T {}
 
 #[rustfmt::skip]
 impl<'a, T> Type for &'a mut T {
@@ -166,7 +167,7 @@ where
     type Align = PointerWidth;
 }
 
-impl<T> StableABI for *const T {}
+impl<D: Direction, A: Aspect, T> Never<D, A> for *const T {}
 
 #[rustfmt::skip]
 impl<T> Type for *const T {
@@ -185,7 +186,7 @@ where
     type Align = PointerWidth;
 }
 
-impl<T> StableABI for *mut T {}
+impl<D: Direction, A: Aspect, T> Never<D, A> for *mut T {}
 
 #[rustfmt::skip]
 impl<T> Type for *mut T {
@@ -211,7 +212,7 @@ impl<T> Type for AtomicPtr<T> {
     #[doc(hidden)] type HighLevel = Self;
 }
 
-impl<T> StableABI for AtomicPtr<T> {}
+impl<D: Direction, A: Aspect, T> Never<D, A> for AtomicPtr<T> {}
 
 impl<ReprAlign, ReprPacked, Visibility, Offset, T> IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset> for AtomicPtr<T>
 where
@@ -235,7 +236,9 @@ where
     #[doc(hidden)] type HighLevel =  <T as Type>::HighLevel;
 }
 
-impl<T> StableABI for Cell<T> {}
+impl<D: Direction, A: Aspect, T> Never<D, A> for Cell<T>
+where T: Never<D, A>
+{}
 
 #[rustfmt::skip]
 impl<T> Type for UnsafeCell<T>
@@ -247,7 +250,9 @@ where
     #[doc(hidden)] type HighLevel =  <T as Type>::HighLevel;
 }
 
-impl<T> StableABI for UnsafeCell<T> {}
+impl<D: Direction, A: Aspect, T> Never<D, A> for UnsafeCell<T>
+where T: Never<D, A>
+{}
 
 macro_rules! array_layout {
   ($($n: expr, $t: ty);*) => {
@@ -258,7 +263,9 @@ macro_rules! array_layout {
             #[doc(hidden)] type HighLevel = Self;
         }
 
-        impl<T> StableABI for [T; $n] {}
+        impl<D: Direction, A: Aspect, T> Never<D, A> for [T; $n]
+        where T: Never<D, A>
+        {}
 
         impl<ReprAlign, ReprPacked, Visibility, Offset, T> IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset>
             for [T; $n]
@@ -324,9 +331,10 @@ where
     #[doc(hidden)] type HighLevel = Self;
 }
 
-impl<T, N> StableABI for GenericArray<T, N>
+impl<D: Direction, A: Aspect, T, N> Never<D, A> for GenericArray<T, N>
 where
     N: ArrayLength<T>,
+    T: Never<D, A>,
 {}
 
 impl<ReprAlign, ReprPacked, Visibility, Offset, T, N> IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset>

--- a/typic/src/private/layout/into_bytelevel/primitives.rs
+++ b/typic/src/private/layout/into_bytelevel/primitives.rs
@@ -22,11 +22,11 @@ macro_rules! primitive_layout {
                 #[doc(hidden)] type HighLevel = Self;
             }
 
-            impl TransmutableFrom for $ty {
+            unsafe impl TransmutableFrom for $ty {
                 type Type = Self;
             }
 
-            impl TransmutableInto for $ty {
+            unsafe impl TransmutableInto for $ty {
                 type Type = Self;
             }
 
@@ -84,11 +84,11 @@ macro_rules! nonzero_layout {
                 #[doc(hidden)] type HighLevel = Self;
             }
 
-            impl TransmutableFrom for $ty {
+            unsafe impl TransmutableFrom for $ty {
                 type Type = Self;
             }
 
-            impl TransmutableInto for $ty {
+            unsafe impl TransmutableInto for $ty {
                 type Type = Self;
             }
 
@@ -129,11 +129,11 @@ impl Type for () {
     #[doc(hidden)] type HighLevel = Self;
 }
 
-impl TransmutableFrom for () {
+unsafe impl TransmutableFrom for () {
     type Type = Self;
 }
 
-impl TransmutableInto for () {
+unsafe impl TransmutableInto for () {
     type Type = Self;
 }
 
@@ -147,12 +147,12 @@ where
     type Align = PointerWidth;
 }
 
-impl<'a, T> TransmutableFrom for &'a T
+unsafe impl<'a, T> TransmutableFrom for &'a T
 {
     type Type = Self;
 }
 
-impl<'a, T> TransmutableInto for &'a T
+unsafe impl<'a, T> TransmutableInto for &'a T
 {
     type Type = Self;
 }
@@ -174,12 +174,12 @@ where
     type Align = PointerWidth;
 }
 
-impl<'a, T> TransmutableFrom for &'a mut T
+unsafe impl<'a, T> TransmutableFrom for &'a mut T
 {
     type Type = Self;
 }
 
-impl<'a, T> TransmutableInto for &'a mut T
+unsafe impl<'a, T> TransmutableInto for &'a mut T
 {
     type Type = Self;
 }
@@ -202,11 +202,11 @@ where
     type Align = PointerWidth;
 }
 
-impl<T> TransmutableFrom for *const T {
+unsafe impl<T> TransmutableFrom for *const T {
     type Type = Self;
 }
 
-impl<T> TransmutableInto for *const T {
+unsafe impl<T> TransmutableInto for *const T {
     type Type = Self;
 }
 
@@ -227,11 +227,11 @@ where
     type Align = PointerWidth;
 }
 
-impl<T> TransmutableFrom for *mut T {
+unsafe impl<T> TransmutableFrom for *mut T {
     type Type = Self;
 }
 
-impl<T> TransmutableInto for *mut T {
+unsafe impl<T> TransmutableInto for *mut T {
     type Type = Self;
 }
 
@@ -259,11 +259,11 @@ impl<T> Type for AtomicPtr<T> {
     #[doc(hidden)] type HighLevel = Self;
 }
 
-impl<T> TransmutableFrom for AtomicPtr<T> {
+unsafe impl<T> TransmutableFrom for AtomicPtr<T> {
     type Type = Self;
 }
 
-impl<T> TransmutableInto for AtomicPtr<T> {
+unsafe impl<T> TransmutableInto for AtomicPtr<T> {
     type Type = Self;
 }
 
@@ -289,12 +289,12 @@ where
     #[doc(hidden)] type HighLevel =  <T as Type>::HighLevel;
 }
 
-impl<T: TransmutableFrom> TransmutableFrom for Cell<T>
+unsafe impl<T: TransmutableFrom> TransmutableFrom for Cell<T>
 {
     type Type = <T as TransmutableFrom>::Type;
 }
 
-impl<T: TransmutableInto> TransmutableInto for Cell<T>
+unsafe impl<T: TransmutableInto> TransmutableInto for Cell<T>
 {
     type Type = <T as TransmutableInto>::Type;
 }
@@ -309,12 +309,12 @@ where
     #[doc(hidden)] type HighLevel =  <T as Type>::HighLevel;
 }
 
-impl<T: TransmutableInto> TransmutableInto for UnsafeCell<T>
+unsafe impl<T: TransmutableInto> TransmutableInto for UnsafeCell<T>
 {
     type Type = <T as TransmutableInto>::Type;
 }
 
-impl<T: TransmutableFrom> TransmutableFrom for UnsafeCell<T>
+unsafe impl<T: TransmutableFrom> TransmutableFrom for UnsafeCell<T>
 {
     type Type = <T as TransmutableFrom>::Type;
 }
@@ -328,14 +328,14 @@ macro_rules! array_layout {
             #[doc(hidden)] type HighLevel = Self;
         }
 
-        impl<T: TransmutableFrom> TransmutableFrom for [T; $n]
+        unsafe impl<T: TransmutableFrom> TransmutableFrom for [T; $n]
         where
             [<T as TransmutableFrom>::Type; $n]: Layout
         {
             type Type = [<T as TransmutableFrom>::Type; $n];
         }
 
-        impl<T: TransmutableInto> TransmutableInto for [T; $n]
+        unsafe impl<T: TransmutableInto> TransmutableInto for [T; $n]
         where
             [<T as TransmutableInto>::Type; $n]: Layout
         {
@@ -406,7 +406,7 @@ where
     #[doc(hidden)] type HighLevel = Self;
 }
 
-impl<T, N> TransmutableFrom for GenericArray<T, N>
+unsafe impl<T, N> TransmutableFrom for GenericArray<T, N>
 where
     N: ArrayLength<T> + ArrayLength<<T as TransmutableFrom>::Type>,
     T: TransmutableFrom,
@@ -415,7 +415,7 @@ where
     type Type = GenericArray<<T as TransmutableFrom>::Type, N>;
 }
 
-impl<T, N> TransmutableInto for GenericArray<T, N>
+unsafe impl<T, N> TransmutableInto for GenericArray<T, N>
 where
     N: ArrayLength<T> + ArrayLength<<T as TransmutableInto>::Type>,
     T: TransmutableInto,

--- a/typic/src/private/layout/into_bytelevel/product.rs
+++ b/typic/src/private/layout/into_bytelevel/product.rs
@@ -6,7 +6,7 @@ use crate::private::layout::{padding::PadTo, IntoByteLevel};
 use crate::private::num::{self, Unsigned};
 
 #[rustfmt::skip]
-impl<ReprAlign, ReprPacked, Offset> IntoByteLevel<ReprAlign, ReprPacked, Offset> for highlevel::PNil
+impl<ReprAlign, ReprPacked, Visibility, Offset> IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset> for highlevel::PNil
 where
     ReprAlign: Unsigned,
     Offset: PadTo<ReprAlign> + num::Add<<Offset as PadTo<ReprAlign>>::Output>,
@@ -32,47 +32,51 @@ where
 }
 
 #[rustfmt::skip]
-impl<ReprAlign, ReprPacked, Offset, F, R>
-IntoByteLevel<ReprAlign, ReprPacked, Offset> for highlevel::PCons<F, R>
+impl<ReprAlign, ReprPacked, Visibility, Offset, F, R>
+IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset> for highlevel::PCons<F, R>
 where
-    F: FieldIntoByteLevel<ReprPacked, Offset>,
-    R: IntoByteLevel<ReprAlign, ReprPacked, <F as FieldIntoByteLevel<ReprPacked, Offset>>::Offset>,
+    F: FieldIntoByteLevel<ReprPacked, Visibility, Offset>,
+    R: IntoByteLevel<ReprAlign, ReprPacked, Visibility, <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset>,
 
-    <F as FieldIntoByteLevel<ReprPacked, Offset>>::Output:
+    <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Output:
         bytelevel::Add<
             <R as IntoByteLevel<
                 ReprAlign,
                 ReprPacked,
-                <F as FieldIntoByteLevel<ReprPacked, Offset>>::Offset,
+                Visibility,
+                <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
             >>::Output,
         >,
 
-    <F as FieldIntoByteLevel<ReprPacked, Offset>>::Align:
+    <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align:
         num::Max<
             <R as IntoByteLevel<
                 ReprAlign,
                 ReprPacked,
-                <F as FieldIntoByteLevel<ReprPacked, Offset>>::Offset,
+                Visibility,
+                <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
             >>::Align,
         >,
 
     num::Maximum<
-        <F as FieldIntoByteLevel<ReprPacked, Offset>>::Align,
+        <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align,
         <R as IntoByteLevel<
             ReprAlign,
             ReprPacked,
-            <F as FieldIntoByteLevel<ReprPacked, Offset>>::Offset,
+            Visibility,
+            <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
         >>::Align,
     >: Unsigned,
 
 {
     type Output =
         bytelevel::Sum<
-            <F as FieldIntoByteLevel<ReprPacked, Offset>>::Output,
+            <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Output,
             <R as IntoByteLevel<
                 ReprAlign,
                 ReprPacked,
-                <F as FieldIntoByteLevel<ReprPacked, Offset>>::Offset,
+                Visibility,
+                <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
             >>::Output,
         >;
 
@@ -80,16 +84,18 @@ where
         <R as IntoByteLevel<
             ReprAlign,
             ReprPacked,
-            <F as FieldIntoByteLevel<ReprPacked, Offset>>::Offset,
+            Visibility,
+            <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
         >>::Offset;
 
     type Align =
         num::Maximum<
-            <F as FieldIntoByteLevel<ReprPacked, Offset>>::Align,
+            <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align,
             <R as IntoByteLevel<
                 ReprAlign,
                 ReprPacked,
-                <F as FieldIntoByteLevel<ReprPacked, Offset>>::Offset,
+                Visibility,
+                <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
             >>::Align,
         >;
 }

--- a/typic/src/private/layout/into_bytelevel/product.rs
+++ b/typic/src/private/layout/into_bytelevel/product.rs
@@ -18,7 +18,7 @@ where
 {
     type Output =
         bytelevel::PCons<
-            PaddingSlot<<Offset as PadTo<ReprAlign>>::Output>,
+            PaddingSlot<Visibility, <Offset as PadTo<ReprAlign>>::Output>,
             bytelevel::PNil
         >;
 

--- a/typic/src/private/layout/into_bytelevel/product.rs
+++ b/typic/src/private/layout/into_bytelevel/product.rs
@@ -36,12 +36,18 @@ impl<ReprAlign, ReprPacked, Visibility, Offset, F, R>
 IntoByteLevel<ReprAlign, ReprPacked, Visibility, Offset> for highlevel::PCons<F, R>
 where
     F: FieldIntoByteLevel<ReprPacked, Visibility, Offset>,
-    R: IntoByteLevel<ReprAlign, ReprPacked, Visibility, <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset>,
+    R: IntoByteLevel<num::Maximum<
+        <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align,
+        ReprAlign,
+    >, ReprPacked, Visibility, <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset>,
 
     <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Output:
         bytelevel::Add<
             <R as IntoByteLevel<
-                ReprAlign,
+                num::Maximum<
+                    <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align,
+                    ReprAlign,
+                >,
                 ReprPacked,
                 Visibility,
                 <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
@@ -49,31 +55,21 @@ where
         >,
 
     <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align:
-        num::Max<
-            <R as IntoByteLevel<
-                ReprAlign,
-                ReprPacked,
-                Visibility,
-                <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
-            >>::Align,
-        >,
+        num::Max<ReprAlign>,
 
     num::Maximum<
         <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align,
-        <R as IntoByteLevel<
-            ReprAlign,
-            ReprPacked,
-            Visibility,
-            <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
-        >>::Align,
+        ReprAlign,
     >: Unsigned,
-
 {
     type Output =
         bytelevel::Sum<
             <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Output,
             <R as IntoByteLevel<
-                ReprAlign,
+                num::Maximum<
+                    <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align,
+                    ReprAlign,
+                >,
                 ReprPacked,
                 Visibility,
                 <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
@@ -82,7 +78,10 @@ where
 
     type Offset =
         <R as IntoByteLevel<
-            ReprAlign,
+            num::Maximum<
+                <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align,
+                ReprAlign,
+            >,
             ReprPacked,
             Visibility,
             <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
@@ -91,11 +90,6 @@ where
     type Align =
         num::Maximum<
             <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Align,
-            <R as IntoByteLevel<
-                ReprAlign,
-                ReprPacked,
-                Visibility,
-                <F as FieldIntoByteLevel<ReprPacked, Visibility, Offset>>::Offset,
-            >>::Align,
+            ReprAlign,
         >;
 }

--- a/typic/src/private/layout/padding.rs
+++ b/typic/src/private/layout/padding.rs
@@ -5,22 +5,22 @@ use crate::private::num::*;
 /// compound type, where `Offset` is the index of the byte following the end of
 /// the preceeding field, and `Packed` is an unsigned integer reflecting the
 /// minimum packing of the enclosing type.
-pub trait PaddingNeededForField<Offset, Packed> {
+pub trait PaddingNeededForField<Visibility, Offset, Packed> {
     type Output: Unsigned;
 }
 
-impl<Offset, Packed, T> PaddingNeededForField<Offset, Packed> for T
+impl<Visibility, Offset, Packed, T> PaddingNeededForField<Visibility, Offset, Packed> for T
 where
-    T: Layout,
-    <T as Layout>::Align: Min<Packed>,
-    Minimum<<T as Layout>::Align, Packed>: Unsigned,
-    Offset: PadTo<Minimum<<T as Layout>::Align, Packed>>,
-    <Offset as PadTo<Minimum<<T as Layout>::Align, Packed>>>::Output: Unsigned,
+    T: Layout<Visibility>,
+    <T as Layout<Visibility>>::Align: Min<Packed>,
+    Minimum<<T as Layout<Visibility>>::Align, Packed>: Unsigned,
+    Offset: PadTo<Minimum<<T as Layout<Visibility>>::Align, Packed>>,
+    <Offset as PadTo<Minimum<<T as Layout<Visibility>>::Align, Packed>>>::Output: Unsigned,
 {
     /// In the presence of a `repr(packed(N))` modifier, this field is packed
     /// to satisfy alignment `N` or the preferred alignment of `T`—whichever is
     /// lower.
-    type Output = <Offset as PadTo<Minimum<<T as Layout>::Align, Packed>>>::Output;
+    type Output = <Offset as PadTo<Minimum<<T as Layout<Visibility>>::Align, Packed>>>::Output;
 }
 
 /// The amount of padding bytes needed to align an item at offset `Self` to

--- a/typic/src/private/layout/test.rs
+++ b/typic/src/private/layout/test.rs
@@ -17,6 +17,6 @@ const _: () = {
     assert_type_eq_all!(<C as Layout<Public>>::Size, U0);
     assert_type_eq_all!(
         <C as Layout<Public>>::ByteLevel,
-        blvl::PCons<PaddingSlot<U0>, blvl::PNil>
+        blvl::PCons<PaddingSlot<Public, U0>, blvl::PNil>
     );
 };

--- a/typic/src/private/layout/test.rs
+++ b/typic/src/private/layout/test.rs
@@ -1,6 +1,6 @@
 use super::Layout;
 use crate::private::bytelevel::{self as blvl, slot::*};
-use crate::private::highlevel::{self as hlvl, MaxAlign, MinAlign, Type};
+use crate::private::highlevel::{self as hlvl, MaxAlign, MinAlign, Type, Public};
 use crate::private::num::*;
 use crate::typic;
 use static_assertions::*;
@@ -13,10 +13,10 @@ const _: () = {
     assert_type_eq_all!(<C as Type>::ReprPacked, MaxAlign);
     assert_type_eq_all!(<C as Type>::HighLevel, hlvl::PNil);
 
-    assert_type_eq_all!(<C as Layout>::Align, U1);
-    assert_type_eq_all!(<C as Layout>::Size, U0);
+    assert_type_eq_all!(<C as Layout<Public>>::Align, U1);
+    assert_type_eq_all!(<C as Layout<Public>>::Size, U0);
     assert_type_eq_all!(
-        <C as Layout>::ByteLevel,
+        <C as Layout<Public>>::ByteLevel,
         blvl::PCons<PaddingSlot<U0>, blvl::PNil>
     );
 };

--- a/typic/src/private/stability.rs
+++ b/typic/src/private/stability.rs
@@ -13,21 +13,21 @@ use crate::layout::Layout;
 use crate::transmute::{self, neglect, TransmuteFrom, TransmuteInto};
 use crate::private::highlevel::Public;
 
-/// Implements all stability restrictions on a type.
+/// Implements [`TransmutableInto`] and [`TransmutableFrom`] for a
+/// type, using that type as its own ABI bound.
+///
+/// You must not make any changes to this type that narrows the
+/// visibility of its fields or changes its layout.
 pub use typic_derive::StableABI;
 
-/// `Self` is always transmutable into `Type`.
+/// Assert that `Self` is always transmutable into `Type`.
 pub trait TransmutableInto
-//  : Bound<Lower>
-//  + TransmuteFrom<<Self as Bound<Lower>>::Type, neglect::Stability>
 {
     type Type: Layout;
 }
 
-/// `Self` is always transmutable from `Type`.
+/// Assert that `Self` is always transmutable from `Type`.
 pub trait TransmutableFrom
-//  : Bound<Upper>
-//  + TransmuteInto<<Self as Bound<Lower>>::Type, neglect::Stability>
 {
     type Type: Layout;
 }

--- a/typic/src/private/stability.rs
+++ b/typic/src/private/stability.rs
@@ -10,35 +10,24 @@
 
 //use crate::private::layout::{self, Layout};
 use crate::layout::Layout;
+use crate::transmute::{self, neglect, TransmuteFrom, TransmuteInto};
 use crate::private::highlevel::Public;
 
 /// Implements all stability restrictions on a type.
 pub use typic_derive::StableABI;
 
-/// Increasing the given aspect is a breaking change.
-pub enum Upper {}
-
-/// Decreasing the given aspect is a breaking change.
-pub enum Lower {}
-
-/// The directionality of the layout guarantee.
-pub trait Direction: private::Sealed {}
-
-impl Direction for Upper {}
-impl Direction for Lower {}
-
-pub trait Bound<Direction>
-where
-    Direction: self::Direction
+/// `Self` is always transmutable into `Type`.
+pub trait TransmutableInto
+//  : Bound<Lower>
+//  + TransmuteFrom<<Self as Bound<Lower>>::Type, neglect::Stability>
 {
     type Type: Layout;
 }
 
-mod private {
-    use super::*;
-
-    pub trait Sealed {}
-
-    impl Sealed for Upper       {}
-    impl Sealed for Lower       {}
+/// `Self` is always transmutable from `Type`.
+pub trait TransmutableFrom
+//  : Bound<Upper>
+//  + TransmuteInto<<Self as Bound<Lower>>::Type, neglect::Stability>
+{
+    type Type: Layout;
 }

--- a/typic/src/private/stability.rs
+++ b/typic/src/private/stability.rs
@@ -37,6 +37,9 @@ impl Aspect for Alignment     {}
 impl Aspect for Size      {}
 impl Aspect for Validity  {}
 
+/// Implements all stability restrictions on a type.
+pub use typic_derive::StableABI;
+
 /// Increasing the given aspect is a breaking change.
 pub enum Increase {}
 

--- a/typic/src/private/stability.rs
+++ b/typic/src/private/stability.rs
@@ -4,70 +4,41 @@
 //! use typic::{self, stability::*};
 //!
 //! #[typic::repr(C)]
+//! #[derive(StableABI)]
 //! struct Foo(u8, u16, u32);
-//!
-//! // Increasing `Foo`'s size from 8 bytes is a breaking change.
-//! impl Never<Increase, Alignment> for Foo {}
-//!
-//! // Decreasing `Foo`'s minimum alignment from 4 is a breaking change. 
-//! impl Never<Decrease, Size>      for Foo {}
-//!
-//! // Increasing `Foo`'s bit-validity is a breaking change. 
-//! impl Never<Increase, Validity>  for Foo {}
 //! ```
 
-/// The minimum alignment aspect of a type's layout.
-pub enum Alignment {}
-
-/// The size aspect of a type's layout.
-pub enum Size {}
-
-/// The validity aspect of a type's layout.
-pub enum Validity {}
-
-/// Aspects of a type's layout.
-///
-/// The layout of a type has three aspects:
-/// 1. [Minimum Alignment][Align]
-/// 2. [Size][Size]
-/// 3. [Validity][Validity]
-pub trait Aspect: private::Sealed {}
-
-impl Aspect for Alignment     {}
-impl Aspect for Size      {}
-impl Aspect for Validity  {}
+//use crate::private::layout::{self, Layout};
+use crate::layout::Layout;
+use crate::private::highlevel::Public;
 
 /// Implements all stability restrictions on a type.
 pub use typic_derive::StableABI;
 
 /// Increasing the given aspect is a breaking change.
-pub enum Increase {}
+pub enum Upper {}
 
 /// Decreasing the given aspect is a breaking change.
-pub enum Decrease {}
+pub enum Lower {}
 
 /// The directionality of the layout guarantee.
 pub trait Direction: private::Sealed {}
 
-impl Direction for Increase {}
-impl Direction for Decrease {}
+impl Direction for Upper {}
+impl Direction for Lower {}
 
-/// Changing the `Aspect` in the `Direction` for `Self` is a breaking change.
-pub trait Never<Direction, Aspect>
+pub trait Bound<Direction>
 where
-    Direction:  self::Direction,
-    Aspect:     self::Aspect,
-{}
+    Direction: self::Direction
+{
+    type Type: Layout;
+}
 
 mod private {
     use super::*;
 
     pub trait Sealed {}
-    
-    impl Sealed for Alignment   {}
-    impl Sealed for Size        {}
-    impl Sealed for Validity    {}
-    
-    impl Sealed for Increase    {}
-    impl Sealed for Decrease    {}
+
+    impl Sealed for Upper       {}
+    impl Sealed for Lower       {}
 }

--- a/typic/src/private/stability.rs
+++ b/typic/src/private/stability.rs
@@ -21,13 +21,13 @@ use crate::private::highlevel::Public;
 pub use typic_derive::StableABI;
 
 /// Assert that `Self` is always transmutable into `Type`.
-pub trait TransmutableInto
+pub unsafe trait TransmutableInto
 {
     type Type: Layout;
 }
 
 /// Assert that `Self` is always transmutable from `Type`.
-pub trait TransmutableFrom
+pub unsafe trait TransmutableFrom
 {
     type Type: Layout;
 }

--- a/typic/src/private/stability.rs
+++ b/typic/src/private/stability.rs
@@ -1,0 +1,70 @@
+//! A type grammar for communicating layout guarantees.
+//!
+//! ```rust
+//! use typic::{self, stability::*};
+//!
+//! #[typic::repr(C)]
+//! struct Foo(u8, u16, u32);
+//!
+//! // Increasing `Foo`'s size from 8 bytes is a breaking change.
+//! impl Never<Increase, Alignment> for Foo {}
+//!
+//! // Decreasing `Foo`'s minimum alignment from 4 is a breaking change. 
+//! impl Never<Decrease, Size>      for Foo {}
+//!
+//! // Increasing `Foo`'s bit-validity is a breaking change. 
+//! impl Never<Increase, Validity>  for Foo {}
+//! ```
+
+/// The minimum alignment aspect of a type's layout.
+pub enum Alignment {}
+
+/// The size aspect of a type's layout.
+pub enum Size {}
+
+/// The validity aspect of a type's layout.
+pub enum Validity {}
+
+/// Aspects of a type's layout.
+///
+/// The layout of a type has three aspects:
+/// 1. [Minimum Alignment][Align]
+/// 2. [Size][Size]
+/// 3. [Validity][Validity]
+pub trait Aspect: private::Sealed {}
+
+impl Aspect for Alignment     {}
+impl Aspect for Size      {}
+impl Aspect for Validity  {}
+
+/// Increasing the given aspect is a breaking change.
+pub enum Increase {}
+
+/// Decreasing the given aspect is a breaking change.
+pub enum Decrease {}
+
+/// The directionality of the layout guarantee.
+pub trait Direction: private::Sealed {}
+
+impl Direction for Increase {}
+impl Direction for Decrease {}
+
+/// Changing the `Aspect` in the `Direction` for `Self` is a breaking change.
+pub trait Never<Direction, Aspect>
+where
+    Direction:  self::Direction,
+    Aspect:     self::Aspect,
+{}
+
+mod private {
+    use super::*;
+
+    pub trait Sealed {}
+    
+    impl Sealed for Alignment   {}
+    impl Sealed for Size        {}
+    impl Sealed for Validity    {}
+    
+    impl Sealed for Increase    {}
+    impl Sealed for Decrease    {}
+}

--- a/typic/src/private/transmute.rs
+++ b/typic/src/private/transmute.rs
@@ -29,11 +29,11 @@ pub mod from_type;
 pub mod from_layout;
 
 /// The source and destination types **must** have
-/// [stable ABIs][crate::marker::StableABI].
+/// [stable ABIs][crate::stability::StableABI].
 pub struct Stable;
 
 /// The source and destination types **may not** both have
-/// [stable ABIs][crate::marker::StableABI].
+/// [stable ABIs][crate::stability::StableABI].
 ///
 /// A transmutation between types with unstable ABIs is not necessarily
 /// unsafe, but the creators of the source and destination types do **not**
@@ -52,8 +52,8 @@ pub struct Unstable;
 ///
 /// [`TransmuteFrom`]: TransmuteFrom
 /// [`safe_transmute`]: safe_transmute
-/// [soundness]: crate::transmute::sound#when-is-a-transmutation-sound
-/// [safety]: crate::transmute::safe
+/// [soundness]: crate::transmute::unsafe_transmutation#when-is-a-transmutation-sound
+/// [safety]: crate::transmute::safe_transmutation
 pub unsafe trait TransmuteInto<U, O = ()>: UnsafeTransmuteInto<U>
 where
     O: neglect::TransmuteOptions,
@@ -105,8 +105,8 @@ where
 ///
 /// [`TransmuteInto`]: TransmuteInto
 /// [`safe_transmute`]: safe_transmute
-/// [soundness]: crate::transmute::sound#when-is-a-transmutation-sound
-/// [safety]: crate::transmute::safe
+/// [soundness]: crate::transmute::unsafe_transmutation#when-is-a-transmutation-sound
+/// [safety]: crate::transmute::safe_transmutation
 pub unsafe trait TransmuteFrom<T, O = ()>: Sized
 where
     O: neglect::TransmuteOptions,
@@ -139,8 +139,8 @@ where
 ///
 /// [`TransmuteFrom`]: TransmuteFrom
 /// [`TransmuteInto`]: TransmuteInto
-/// [soundness]: crate::transmute::sound#when-is-a-transmutation-sound
-/// [safety]: crate::transmute::safe
+/// [soundness]: crate::transmute::unsafe_transmutation#when-is-a-transmutation-sound
+/// [safety]: crate::transmute::safe_transmutation
 #[inline(always)]
 pub fn safe_transmute<T, U, O>(from: T) -> U
 where
@@ -170,8 +170,8 @@ where
 ///
 /// [`UnsafeTransmuteFrom`]: UnsafeTransmuteFrom
 /// [`unsafe_transmute`]: unsafe_transmute
-/// [soundness]: crate::transmute::sound#when-is-a-transmutation-sound
-/// [safety]: crate::safe
+/// [soundness]: crate::transmute::unsafe_transmutation#when-is-a-transmutation-sound
+/// [safety]: crate::transmute::safe_transmutation
 pub unsafe trait UnsafeTransmuteInto<U, O = ()>: Sized
 where
     O: neglect::UnsafeTransmuteOptions,
@@ -199,10 +199,10 @@ where
 ///
 /// See also [`unsafe_transmute`].
 ///
-/// [`UnsafeTransmuteInto`]: crate::TransmuteInto
-/// [`unsafe_transmute`]: crate::unsafe_transmute
-/// [soundness]: crate::sound#when-is-a-transmutation-sound
-/// [safety]: crate::safe
+/// [`UnsafeTransmuteInto`]: crate::transmute::TransmuteInto
+/// [`unsafe_transmute`]: crate::transmute::unsafe_transmute
+/// [soundness]: crate::transmute::unsafe_transmutation#when-is-a-transmutation-sound
+/// [safety]: crate::transmute::safe_transmutation
 pub unsafe trait UnsafeTransmuteFrom<T, O = ()>: Sized
 where
     O: neglect::UnsafeTransmuteOptions,
@@ -240,8 +240,8 @@ where
 /// additional validity restrictions in its constructor(s). This function
 /// bypasses those restrictions, and may lead to later unsoundness.
 ///
-/// [soundness]: crate::sound#when-is-a-transmutation-sound
-/// [safety]: crate::safe
+/// [soundness]: crate::transmute::unsafe_transmutation#when-is-a-transmutation-sound
+/// [safety]: crate::transmute::safe_transmutation
 #[inline(always)]
 pub unsafe fn unsafe_transmute<T, U, O>(from: T) -> U
 where

--- a/typic/src/private/transmute.rs
+++ b/typic/src/private/transmute.rs
@@ -15,6 +15,11 @@ pub struct Enforced;
 /// Transparency is not enforced.
 pub struct Unenforced;
 
+/// Validity is always enforced.
+pub struct AlwaysValid;
+/// Some invalidity is allowed.
+pub struct MaybeInvalid;
+
 pub mod neglect;
 
 #[rustfmt::skip]
@@ -144,6 +149,7 @@ where
         <O as neglect::UnsafeTransmuteOptions>::Alignment,
         <O as neglect::UnsafeTransmuteOptions>::Transparency,
         <O as neglect::UnsafeTransmuteOptions>::Stability,
+        <O as neglect::UnsafeTransmuteOptions>::Validity,
       >,
     O: neglect::TransmuteOptions,
 {
@@ -212,6 +218,7 @@ where
         <O as neglect::UnsafeTransmuteOptions>::Alignment,
         <O as neglect::UnsafeTransmuteOptions>::Transparency,
         <O as neglect::UnsafeTransmuteOptions>::Stability,
+        <O as neglect::UnsafeTransmuteOptions>::Validity,
       >,
     O: neglect::UnsafeTransmuteOptions,
 {
@@ -242,7 +249,8 @@ where
         Variant,
         <O as neglect::UnsafeTransmuteOptions>::Alignment,
         <O as neglect::UnsafeTransmuteOptions>::Transparency,
-        <O as neglect::UnsafeTransmuteOptions>::Stability>,
+        <O as neglect::UnsafeTransmuteOptions>::Stability,
+        <O as neglect::UnsafeTransmuteOptions>::Validity>,
     O: neglect::UnsafeTransmuteOptions,
 {
     let to = mem::transmute_copy(&from);

--- a/typic/src/private/transmute/from_layout.rs
+++ b/typic/src/private/transmute/from_layout.rs
@@ -107,21 +107,21 @@ mod bytes_to {
       ($($TKind: path => $UKind: path,)*) => {
         $(
           /// Regardless of variance and transparency, this `pub` to `pub` conversion is safe.
-          impl<A, B, C, D, Variance, Transparency, Validity>
-          BytesFromBytes<Bytes<Pub,  $TKind, num::UInt<A, B>>, Variance, Transparency, Validity>
-                     for Bytes<Pub,  $UKind, num::UInt<C, D>>
+          impl<TSize, USize, Variance, Transparency, Validity>
+          BytesFromBytes<Bytes<Pub,  $TKind, TSize>, Variance, Transparency, Validity>
+                     for Bytes<Pub,  $UKind, USize>
           {}
 
           /// A `priv` to `pub` conversion is safe only if the transmutation is variant.
-          impl<A, B, C, D, Transparency, Validity>
-          BytesFromBytes<Bytes<Priv, $TKind, num::UInt<A, B>>, Variant, Transparency, Validity>
-                     for Bytes<Pub,  $UKind, num::UInt<C, D>>
+          impl<TSize, USize, Transparency, Validity>
+          BytesFromBytes<Bytes<Priv, $TKind, TSize>, Variant, Transparency, Validity>
+                     for Bytes<Pub,  $UKind, USize>
           {}
 
           /// A `priv`/`pub` to `priv` conversion is only safe if transparency is unchecked.
-          impl<A, B, C, D, TVis, Variance, Validity>
-          BytesFromBytes<Bytes<TVis, $TKind, num::UInt<A, B>>, Variance, Unenforced, Validity>
-                     for Bytes<Priv, $UKind, num::UInt<C, D>>
+          impl<TSize, USize, TVis, Variance, Validity>
+          BytesFromBytes<Bytes<TVis, $TKind, TSize>, Variance, Unenforced, Validity>
+                     for Bytes<Priv, $UKind, USize>
           {}
         )*
       };
@@ -137,21 +137,21 @@ mod bytes_to {
       ($($TKind: path => $UKind: path,)*) => {
         $(
           /// Regardless of variance and transparency, this `pub` to `pub` conversion is safe.
-          impl<A, B, C, D, Transparency, Validity>
-          BytesFromBytes<Bytes<Pub,  $TKind, num::UInt<A, B>>, Variant, Transparency, Validity>
-                     for Bytes<Pub,  $UKind, num::UInt<C, D>>
+          impl<TSize, USize, Transparency, Validity>
+          BytesFromBytes<Bytes<Pub,  $TKind, TSize>, Variant, Transparency, Validity>
+                     for Bytes<Pub,  $UKind, USize>
           {}
 
           /// A `priv` to `pub` conversion is safe only if the transmutation is variant.
-          impl<A, B, C, D, Transparency, Validity>
-          BytesFromBytes<Bytes<Priv, $TKind, num::UInt<A, B>>, Variant, Transparency, Validity>
-                     for Bytes<Pub,  $UKind, num::UInt<C, D>>
+          impl<TSize, USize, Transparency, Validity>
+          BytesFromBytes<Bytes<Priv, $TKind, TSize>, Variant, Transparency, Validity>
+                     for Bytes<Pub,  $UKind, USize>
           {}
 
           /// A `priv`/`pub` to `priv` conversion is only safe if transparency is unchecked.
-          impl<A, B, C, D, TVis, Validity>
-          BytesFromBytes<Bytes<TVis, $TKind, num::UInt<A, B>>, Variant, Unenforced, Validity>
-                     for Bytes<Priv, $UKind, num::UInt<C, D>>
+          impl<TSize, USize, TVis, Validity>
+          BytesFromBytes<Bytes<TVis, $TKind, TSize>, Variant, Unenforced, Validity>
+                     for Bytes<Priv, $UKind, USize>
           {}
         )*
       };
@@ -163,19 +163,23 @@ mod bytes_to {
       kind::Initialized   => kind::Uninitialized ,
     ];
 
-
     // If either sizes are empty, `BytesFromBytes` vacuously holds.
-    impl<TKind, UKind, Variance, Transparency, Validity> BytesFromBytes<Bytes<Pub, TKind, num::UTerm>, Variance, Transparency, Validity> for Bytes<Pub, UKind, num::UTerm> {}
-    impl<TKind, A, B, UKind, Variance, Transparency, Validity> BytesFromBytes<Bytes<Pub, TKind, num::UInt<A, B>>, Variance, Transparency, Validity> for Bytes<Pub, UKind, num::UTerm> {}
-    impl<TKind, UKind, A, B, Variance, Transparency, Validity> BytesFromBytes<Bytes<Pub, TKind, num::UTerm>, Variance, Transparency, Validity> for Bytes<Pub, UKind, num::UInt<A, B>> {}
+    // this is sketchy, but I think it's alright because of how
+    // BytesFromBytes is used alongside `Consume`. Unfortunately,
+    // it's been months since I last touched this code.
+    // todo: refactor all of this.
+    impl<A, B, Variance, Transparency, Validity>
+      BytesFromBytes<Bytes<Pub, kind::Uninitialized, num::UTerm>, Variance, Transparency, Validity>
+    for              Bytes<Pub, kind::Initialized, num::UInt<A, B>> {}
 
-    /// [Bytes|_] -> [Reference|_]
-    #[rustfmt::skip] unsafe impl<'u, TVis, TKind, TRest, UVis, UK, U, URest, Options>
-    FromLayout<PCons<Bytes<TVis, TKind, num::UTerm>, TRest>, Options>
-         for PCons<Reference<'u, UVis, UK, U>, URest>
-    where
-        Self: FromLayout<TRest, Options>,
-    {}
+    // todo: wtf. why did I write this?
+    // /// [Bytes|_] -> [Reference|_]
+    // #[rustfmt::skip] unsafe impl<'u, TVis, TKind, TRest, UVis, UK, U, URest, Options>
+    // FromLayout<PCons<Bytes<TVis, TKind, num::UTerm>, TRest>, Options>
+    //      for PCons<Reference<'u, UVis, UK, U>, URest>
+    // where
+    //     Self: FromLayout<TRest, Options>,
+    // {}
 }
 
 mod array_to {

--- a/typic/src/private/transmute/from_layout.rs
+++ b/typic/src/private/transmute/from_layout.rs
@@ -244,8 +244,8 @@ mod reference_to {
 
     impl<T, U> FromAlignment<T, Stable> for U
     where
-        U: Bound<Upper>,
-        T: Bound<Lower>,
+        U: TransmutableInto,
+        T: TransmutableFrom,
     {}
 
     impl<T, U> FromAlignment<T, Unstable> for U {}

--- a/typic/src/private/transmute/from_layout.rs
+++ b/typic/src/private/transmute/from_layout.rs
@@ -308,18 +308,18 @@ mod test {
     use crate::private::bytelevel as blvl;
 
     subsumes::<
-      P![PaddingSlot<U2>],
+      P![PaddingSlot<Pub, U2>],
       P![]
     >();
 
     subsumes::<
-      P![PaddingSlot<U2>],
-      P![PaddingSlot<U1>]
+      P![PaddingSlot<Pub, U2>],
+      P![PaddingSlot<Pub, U1>]
     >();
 
     subsumes::<
-      P![PaddingSlot<U1>, PaddingSlot<U1>],
-      P![PaddingSlot<U2>]
+      P![PaddingSlot<Pub, U1>, PaddingSlot<Pub, U1>],
+      P![PaddingSlot<Pub, U2>]
     >();
   }
 }

--- a/typic/src/private/transmute/from_layout.rs
+++ b/typic/src/private/transmute/from_layout.rs
@@ -244,8 +244,8 @@ mod reference_to {
 
     impl<T, U> FromAlignment<T, Stable> for U
     where
-        U: Never<Increase, Alignment>,
-        T: Never<Decrease, Alignment>,
+        U: Bound<Upper>,
+        T: Bound<Lower>,
     {}
 
     impl<T, U> FromAlignment<T, Unstable> for U {}
@@ -257,8 +257,6 @@ mod reference_to {
     where
         't: 'u,
         UK: FromMutability<TK>,
-        U: Never<Increase, Alignment>,
-        T: Never<Decrease, Alignment>,
         U: FromType<T, Invariant, Unchecked, Transparency, Stability, Validity>,
     {}
 

--- a/typic/src/private/transmute/from_layout/flatten.rs
+++ b/typic/src/private/transmute/from_layout/flatten.rs
@@ -7,23 +7,23 @@ pub trait Flatten {
     type Output;
 }
 
-impl<T, TRest> Flatten for PCons<Array<T, num::UTerm>, TRest>
+impl<Vis, T, TRest> Flatten for PCons<Array<Vis, T, num::UTerm>, TRest>
 where
 {
     type Output = TRest;
 }
 
-impl<T, A, B, TRest> Flatten for PCons<Array<T, num::UInt<A, B>>, TRest>
+impl<Vis, T, A, B, TRest> Flatten for PCons<Array<Vis, T, num::UInt<A, B>>, TRest>
 where
-    T: Layout,
+    T: Layout<Vis>,
     num::UInt<A, B>: num::Sub<num::B1>,
 
-    <T as Layout>::ByteLevel:
-      blv::Add<PCons<Array<T, num::Sub1<num::UInt<A, B>>>, TRest>>,
+    <T as Layout<Vis>>::ByteLevel:
+      blv::Add<PCons<Array<Vis, T, num::Sub1<num::UInt<A, B>>>, TRest>>,
 {
     type Output =
       blv::Sum<
-        <T as Layout>::ByteLevel,
-        PCons<Array<T, num::Sub1<num::UInt<A, B>>>, TRest>
+        <T as Layout<Vis>>::ByteLevel,
+        PCons<Array<Vis, T, num::Sub1<num::UInt<A, B>>>, TRest>
       >;
 }

--- a/typic/src/private/transmute/from_type.rs
+++ b/typic/src/private/transmute/from_type.rs
@@ -15,28 +15,32 @@ pub unsafe trait FromType<
   Transparency,
   /// Must the source and destination types have stable representations?
   Stability,
+  /// Must all values of the source type be a valid instance of the destination type?
+  Validity,
 >{}
 
-unsafe impl<T, U, Variance, Alignment, Transparency>
-FromType<T, Variance, Alignment, Transparency, Unstable> for U
+unsafe impl<T, U, Variance, Alignment, Transparency, Validity>
+FromType<T, Variance, Alignment, Transparency, Unstable, Validity> for U
 where
     T: Layout<Public>,
     U: Layout<Public>,
     <U as Layout<Public>>::ByteLevel: FromLayout<<T as Layout<Public>>::ByteLevel,
-      Variance,
+      (Variance,
       Alignment,
       Transparency,
-      Unstable>
+      Unstable,
+      Validity,)>
 {}
 
-unsafe impl<T, U, Variance, Alignment, Transparency>
-FromType<T, Variance, Alignment, Transparency, Stable> for U
+unsafe impl<T, U, Variance, Alignment, Transparency, Validity>
+FromType<T, Variance, Alignment, Transparency, Stable, Validity> for U
 where
     T: Never<Increase, Size> + Layout<Public>,
     U: Never<Decrease, Size> + Layout<Public>,
     <U as Layout<Public>>::ByteLevel: FromLayout<<T as Layout<Public>>::ByteLevel,
-      Variance,
+      (Variance,
       Alignment,
       Transparency,
-      Stable>
+      Stable,
+      Validity,)>
 {}

--- a/typic/src/private/transmute/from_type.rs
+++ b/typic/src/private/transmute/from_type.rs
@@ -1,14 +1,42 @@
-use super::{Relax, Constrain, Safe, Sound};
+use crate::StableABI;
 use crate::private::layout::Layout;
-use super::from_layout::FromLayout;
+use crate::internal::{Public, Private};
+use super::{Stable, Unstable, from_layout::FromLayout};
 
 /// A marker trait implemented if every instance of `T` is transmutable into
 /// an instance of `Self`.
-pub unsafe trait FromType<T, M, S> {}
+pub unsafe trait FromType<
+  SourceType,
+  // Can bit-validity be widened?
+  Variance,
+  // Is alignment checked?
+  Alignment,
+  // Is library safety checked?
+  Transparency,
+  /// Must the source and destination types have stable representations?
+  Stability,
+>{}
 
-unsafe impl<T, U, M, S> FromType<T, M, S> for U
+unsafe impl<T, U, Variance, Alignment, Transparency>
+FromType<T, Variance, Alignment, Transparency, Unstable> for U
 where
-    T: Layout,
-    U: Layout,
-    <U as Layout>::ByteLevel: FromLayout<<T as Layout>::ByteLevel, M, S>
+    T: Layout<Public>,
+    U: Layout<Public>,
+    <U as Layout<Public>>::ByteLevel: FromLayout<<T as Layout<Public>>::ByteLevel,
+      Variance,
+      Alignment,
+      Transparency,
+      Unstable>
+{}
+
+unsafe impl<T, U, Variance, Alignment, Transparency>
+FromType<T, Variance, Alignment, Transparency, Stable> for U
+where
+    T: StableABI + Layout<Public>,
+    U: StableABI + Layout<Public>,
+    <U as Layout<Public>>::ByteLevel: FromLayout<<T as Layout<Public>>::ByteLevel,
+      Variance,
+      Alignment,
+      Transparency,
+      Stable>
 {}

--- a/typic/src/private/transmute/from_type.rs
+++ b/typic/src/private/transmute/from_type.rs
@@ -1,4 +1,4 @@
-use crate::StableABI;
+use crate::stability::*;
 use crate::private::layout::Layout;
 use crate::internal::{Public, Private};
 use super::{Stable, Unstable, from_layout::FromLayout};
@@ -32,8 +32,8 @@ where
 unsafe impl<T, U, Variance, Alignment, Transparency>
 FromType<T, Variance, Alignment, Transparency, Stable> for U
 where
-    T: StableABI + Layout<Public>,
-    U: StableABI + Layout<Public>,
+    T: Never<Increase, Size> + Layout<Public>,
+    U: Never<Decrease, Size> + Layout<Public>,
     <U as Layout<Public>>::ByteLevel: FromLayout<<T as Layout<Public>>::ByteLevel,
       Variance,
       Alignment,

--- a/typic/src/private/transmute/from_type.rs
+++ b/typic/src/private/transmute/from_type.rs
@@ -35,8 +35,21 @@ where
 unsafe impl<T, U, Variance, Alignment, Transparency, Validity>
 FromType<T, Variance, Alignment, Transparency, Stable, Validity> for U
 where
-    T: Never<Increase, Size> + Layout<Public>,
-    U: Never<Decrease, Size> + Layout<Public>,
+    T: Bound<Upper> + Layout<Public>,
+    U: Bound<Lower> + Layout<Public>,
+
+    // If stability is being enforced, then
+    // the widest extent of the source type
+    // must be transmutable into the narrowest
+    // extent of the destination type.
+    <U as Bound<Lower>>::Type:
+      FromType<<T as Bound<Upper>>::Type,
+        Variance,
+        Alignment,
+        Transparency,
+        Unstable,
+        Validity>,
+
     <U as Layout<Public>>::ByteLevel: FromLayout<<T as Layout<Public>>::ByteLevel,
       (Variance,
       Alignment,

--- a/typic/src/private/transmute/from_type.rs
+++ b/typic/src/private/transmute/from_type.rs
@@ -35,15 +35,15 @@ where
 unsafe impl<T, U, Variance, Alignment, Transparency, Validity>
 FromType<T, Variance, Alignment, Transparency, Stable, Validity> for U
 where
-    T: Bound<Upper> + Layout<Public>,
-    U: Bound<Lower> + Layout<Public>,
+    T: TransmutableFrom + Layout<Public>,
+    U: TransmutableInto + Layout<Public>,
 
     // If stability is being enforced, then
     // the widest extent of the source type
     // must be transmutable into the narrowest
     // extent of the destination type.
-    <U as Bound<Lower>>::Type:
-      FromType<<T as Bound<Upper>>::Type,
+    <U as TransmutableInto>::Type:
+      FromType<<T as TransmutableFrom>::Type,
         Variance,
         Alignment,
         Transparency,

--- a/typic/src/private/transmute/neglect.rs
+++ b/typic/src/private/transmute/neglect.rs
@@ -9,6 +9,7 @@ pub struct Transparency;
 /// in-memory representations.
 pub struct Stability;
 
+/// Options for safe and unsafe transmutation.
 pub trait TransmuteOptions: UnsafeTransmuteOptions {
     type Stability;
 }
@@ -30,6 +31,7 @@ where
     type Stability      = <O as TransmuteOptions>::Stability;
 }
 
+/// Options for unsafe transmutation.
 pub trait UnsafeTransmuteOptions {
     type Alignment;
     type Transparency;

--- a/typic/src/private/transmute/neglect.rs
+++ b/typic/src/private/transmute/neglect.rs
@@ -1,0 +1,127 @@
+/// Neglect statically guaranteeing pointer alignments.
+pub struct Alignment;
+
+/// Neglect guaranteeing that corresponding bytes in the source and destination
+/// types have appropriate visibility.
+pub struct Transparency;
+
+/// Neglect guaranteeing that the source and destination types have stable
+/// in-memory representations.
+pub struct Stability;
+
+pub trait Options: UnsafeOptions {
+    type Stability;
+}
+
+impl Options for () {
+    type Stability    = super::Stable;
+}
+
+impl Options for Stability {
+    type Stability    = super::Unstable;
+}
+
+impl<O> UnsafeOptions for O
+where
+    O: Options
+{
+    type Alignment      = super::Static;
+    type Transparency   = super::Enforced;
+    type Stability      = <O as Options>::Stability;
+}
+
+pub trait UnsafeOptions {
+    type Alignment;
+    type Transparency;
+    type Stability;
+}
+
+impl UnsafeOptions for Alignment {
+    type Alignment    = super::Unchecked;
+    type Stability    = super::Stable;
+    type Transparency = super::Enforced;
+}
+
+impl UnsafeOptions for (Alignment,) {
+    type Alignment    = super::Unchecked;
+    type Stability    = super::Stable;
+    type Transparency = super::Enforced;
+}
+
+impl UnsafeOptions for Transparency {
+    type Alignment    = super::Static;
+    type Stability    = super::Stable;
+    type Transparency = super::Unenforced;
+}
+
+impl UnsafeOptions for (Transparency,) {
+    type Alignment    = super::Static;
+    type Stability    = super::Stable;
+    type Transparency = super::Unenforced;
+}
+
+impl UnsafeOptions for (Alignment, Transparency) {
+    type Alignment    = super::Unchecked;
+    type Stability    = super::Stable;
+    type Transparency = super::Unenforced;
+}
+
+impl UnsafeOptions for (Transparency, Alignment) {
+    type Alignment    = super::Unchecked;
+    type Stability    = super::Stable;
+    type Transparency = super::Unenforced;
+}
+
+impl UnsafeOptions for (Alignment, Stability) {
+    type Alignment    = super::Unchecked;
+    type Stability    = super::Unstable;
+    type Transparency = super::Enforced;
+}
+
+impl UnsafeOptions for (Stability, Alignment) {
+    type Alignment    = super::Unchecked;
+    type Stability    = super::Unstable;
+    type Transparency = super::Enforced;
+}
+
+impl UnsafeOptions for (Stability, Transparency) {
+    type Alignment    = super::Static;
+    type Stability    = super::Unstable;
+    type Transparency = super::Unenforced;
+}
+
+impl UnsafeOptions for (Alignment, Transparency, Stability) {
+    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
+    type Stability    = <Stability as UnsafeOptions>::Stability;
+    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+}
+
+impl UnsafeOptions for (Stability, Alignment, Transparency) {
+    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
+    type Stability    = <Stability as UnsafeOptions>::Stability;
+    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+}
+
+impl UnsafeOptions for (Transparency, Stability, Alignment) {
+    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
+    type Stability    = <Stability as UnsafeOptions>::Stability;
+    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+}
+
+impl UnsafeOptions for (Transparency, Alignment, Stability) {
+    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
+    type Stability    = <Stability as UnsafeOptions>::Stability;
+    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+}
+
+impl UnsafeOptions for (Alignment, Stability, Transparency) {
+    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
+    type Stability    = <Stability as UnsafeOptions>::Stability;
+    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+}
+
+impl UnsafeOptions for (Stability, Transparency, Alignment) {
+    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
+    type Stability    = <Stability as UnsafeOptions>::Stability;
+    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+}

--- a/typic/src/private/transmute/neglect.rs
+++ b/typic/src/private/transmute/neglect.rs
@@ -9,6 +9,10 @@ pub struct Transparency;
 /// in-memory representations.
 pub struct Stability;
 
+/// Neglect guaranteeing that all instances of the source type are bit-valid
+/// instances of the destination type. 
+pub struct Validity;
+
 /// Options for safe and unsafe transmutation.
 pub trait TransmuteOptions: UnsafeTransmuteOptions {
     type Stability;
@@ -29,6 +33,7 @@ where
     type Alignment      = super::Static;
     type Transparency   = super::Enforced;
     type Stability      = <O as TransmuteOptions>::Stability;
+    type Validity       = super::AlwaysValid;
 }
 
 /// Options for unsafe transmutation.
@@ -36,94 +41,125 @@ pub trait UnsafeTransmuteOptions {
     type Alignment;
     type Transparency;
     type Stability;
+    type Validity;
 }
 
 impl UnsafeTransmuteOptions for Alignment {
     type Alignment    = super::Unchecked;
     type Stability    = super::Stable;
     type Transparency = super::Enforced;
+    type Validity     = super::AlwaysValid;
 }
 
 impl UnsafeTransmuteOptions for (Alignment,) {
     type Alignment    = super::Unchecked;
     type Stability    = super::Stable;
     type Transparency = super::Enforced;
+    type Validity     = super::AlwaysValid;
 }
 
 impl UnsafeTransmuteOptions for Transparency {
     type Alignment    = super::Static;
     type Stability    = super::Stable;
     type Transparency = super::Unenforced;
+    type Validity     = super::AlwaysValid;
 }
 
 impl UnsafeTransmuteOptions for (Transparency,) {
     type Alignment    = super::Static;
     type Stability    = super::Stable;
     type Transparency = super::Unenforced;
+    type Validity     = super::AlwaysValid;
+}
+
+impl UnsafeTransmuteOptions for Validity {
+    type Alignment    = super::Static;
+    type Stability    = super::Stable;
+    type Transparency = super::Unenforced;
+    type Validity     = super::AlwaysValid;
+}
+
+impl UnsafeTransmuteOptions for (Validity,) {
+    type Alignment    = super::Static;
+    type Stability    = super::Stable;
+    type Transparency = super::Enforced;
+    type Validity     = super::MaybeInvalid;
 }
 
 impl UnsafeTransmuteOptions for (Alignment, Transparency) {
-    type Alignment    = super::Unchecked;
-    type Stability    = super::Stable;
-    type Transparency = super::Unenforced;
-}
-
-impl UnsafeTransmuteOptions for (Transparency, Alignment) {
-    type Alignment    = super::Unchecked;
-    type Stability    = super::Stable;
-    type Transparency = super::Unenforced;
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }
 
 impl UnsafeTransmuteOptions for (Alignment, Stability) {
-    type Alignment    = super::Unchecked;
-    type Stability    = super::Unstable;
-    type Transparency = super::Enforced;
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }
 
-impl UnsafeTransmuteOptions for (Stability, Alignment) {
-    type Alignment    = super::Unchecked;
-    type Stability    = super::Unstable;
-    type Transparency = super::Enforced;
+impl UnsafeTransmuteOptions for (Alignment, Validity) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }
 
-impl UnsafeTransmuteOptions for (Stability, Transparency) {
-    type Alignment    = super::Static;
-    type Stability    = super::Unstable;
-    type Transparency = super::Unenforced;
+impl UnsafeTransmuteOptions for (Transparency, Stability) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
+}
+
+impl UnsafeTransmuteOptions for (Transparency, Validity) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
+}
+
+impl UnsafeTransmuteOptions for (Stability, Validity) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }
 
 impl UnsafeTransmuteOptions for (Alignment, Transparency, Stability) {
     type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
     type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
     type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }
 
-impl UnsafeTransmuteOptions for (Stability, Alignment, Transparency) {
+impl UnsafeTransmuteOptions for (Alignment, Transparency, Validity) {
     type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
     type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
     type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }
 
-impl UnsafeTransmuteOptions for (Transparency, Stability, Alignment) {
+impl UnsafeTransmuteOptions for (Alignment, Stability, Validity) {
     type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
     type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
     type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }
 
-impl UnsafeTransmuteOptions for (Transparency, Alignment, Stability) {
+impl UnsafeTransmuteOptions for (Transparency, Stability, Validity) {
     type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
     type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
     type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }
 
-impl UnsafeTransmuteOptions for (Alignment, Stability, Transparency) {
+
+impl UnsafeTransmuteOptions for (Alignment, Transparency, Stability, Validity) {
     type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
     type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
     type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
-}
-
-impl UnsafeTransmuteOptions for (Stability, Transparency, Alignment) {
-    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
-    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
-    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
+    type Validity     = <Validity as UnsafeTransmuteOptions>::Validity;
 }

--- a/typic/src/private/transmute/neglect.rs
+++ b/typic/src/private/transmute/neglect.rs
@@ -9,119 +9,119 @@ pub struct Transparency;
 /// in-memory representations.
 pub struct Stability;
 
-pub trait Options: UnsafeOptions {
+pub trait TransmuteOptions: UnsafeTransmuteOptions {
     type Stability;
 }
 
-impl Options for () {
+impl TransmuteOptions for () {
     type Stability    = super::Stable;
 }
 
-impl Options for Stability {
+impl TransmuteOptions for Stability {
     type Stability    = super::Unstable;
 }
 
-impl<O> UnsafeOptions for O
+impl<O> UnsafeTransmuteOptions for O
 where
-    O: Options
+    O: TransmuteOptions
 {
     type Alignment      = super::Static;
     type Transparency   = super::Enforced;
-    type Stability      = <O as Options>::Stability;
+    type Stability      = <O as TransmuteOptions>::Stability;
 }
 
-pub trait UnsafeOptions {
+pub trait UnsafeTransmuteOptions {
     type Alignment;
     type Transparency;
     type Stability;
 }
 
-impl UnsafeOptions for Alignment {
+impl UnsafeTransmuteOptions for Alignment {
     type Alignment    = super::Unchecked;
     type Stability    = super::Stable;
     type Transparency = super::Enforced;
 }
 
-impl UnsafeOptions for (Alignment,) {
+impl UnsafeTransmuteOptions for (Alignment,) {
     type Alignment    = super::Unchecked;
     type Stability    = super::Stable;
     type Transparency = super::Enforced;
 }
 
-impl UnsafeOptions for Transparency {
+impl UnsafeTransmuteOptions for Transparency {
     type Alignment    = super::Static;
     type Stability    = super::Stable;
     type Transparency = super::Unenforced;
 }
 
-impl UnsafeOptions for (Transparency,) {
+impl UnsafeTransmuteOptions for (Transparency,) {
     type Alignment    = super::Static;
     type Stability    = super::Stable;
     type Transparency = super::Unenforced;
 }
 
-impl UnsafeOptions for (Alignment, Transparency) {
+impl UnsafeTransmuteOptions for (Alignment, Transparency) {
     type Alignment    = super::Unchecked;
     type Stability    = super::Stable;
     type Transparency = super::Unenforced;
 }
 
-impl UnsafeOptions for (Transparency, Alignment) {
+impl UnsafeTransmuteOptions for (Transparency, Alignment) {
     type Alignment    = super::Unchecked;
     type Stability    = super::Stable;
     type Transparency = super::Unenforced;
 }
 
-impl UnsafeOptions for (Alignment, Stability) {
+impl UnsafeTransmuteOptions for (Alignment, Stability) {
     type Alignment    = super::Unchecked;
     type Stability    = super::Unstable;
     type Transparency = super::Enforced;
 }
 
-impl UnsafeOptions for (Stability, Alignment) {
+impl UnsafeTransmuteOptions for (Stability, Alignment) {
     type Alignment    = super::Unchecked;
     type Stability    = super::Unstable;
     type Transparency = super::Enforced;
 }
 
-impl UnsafeOptions for (Stability, Transparency) {
+impl UnsafeTransmuteOptions for (Stability, Transparency) {
     type Alignment    = super::Static;
     type Stability    = super::Unstable;
     type Transparency = super::Unenforced;
 }
 
-impl UnsafeOptions for (Alignment, Transparency, Stability) {
-    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
-    type Stability    = <Stability as UnsafeOptions>::Stability;
-    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+impl UnsafeTransmuteOptions for (Alignment, Transparency, Stability) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
 }
 
-impl UnsafeOptions for (Stability, Alignment, Transparency) {
-    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
-    type Stability    = <Stability as UnsafeOptions>::Stability;
-    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+impl UnsafeTransmuteOptions for (Stability, Alignment, Transparency) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
 }
 
-impl UnsafeOptions for (Transparency, Stability, Alignment) {
-    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
-    type Stability    = <Stability as UnsafeOptions>::Stability;
-    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+impl UnsafeTransmuteOptions for (Transparency, Stability, Alignment) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
 }
 
-impl UnsafeOptions for (Transparency, Alignment, Stability) {
-    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
-    type Stability    = <Stability as UnsafeOptions>::Stability;
-    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+impl UnsafeTransmuteOptions for (Transparency, Alignment, Stability) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
 }
 
-impl UnsafeOptions for (Alignment, Stability, Transparency) {
-    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
-    type Stability    = <Stability as UnsafeOptions>::Stability;
-    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+impl UnsafeTransmuteOptions for (Alignment, Stability, Transparency) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
 }
 
-impl UnsafeOptions for (Stability, Transparency, Alignment) {
-    type Alignment    = <Alignment as UnsafeOptions>::Alignment;
-    type Stability    = <Stability as UnsafeOptions>::Stability;
-    type Transparency = <Transparency as UnsafeOptions>::Transparency;
+impl UnsafeTransmuteOptions for (Stability, Transparency, Alignment) {
+    type Alignment    = <Alignment as UnsafeTransmuteOptions>::Alignment;
+    type Stability    = <Stability as UnsafeTransmuteOptions>::Stability;
+    type Transparency = <Transparency as UnsafeTransmuteOptions>::Transparency;
 }

--- a/typic/src/transmute.rs
+++ b/typic/src/transmute.rs
@@ -1,0 +1,74 @@
+//! Traits for safe and sound transmutation.
+//!
+//! [soundness]: crate::sound#when-is-a-transmutation-sound
+//! [safety]: crate::safe
+//!
+//! ## Three Types of Transmutation
+//!
+//! ### Unsound Transmutation
+//! [`transmute`]: core::mem::transmute
+//! [`transmute_copy`]: core::mem::transmute_copy
+//!
+//! The [`transmute`] and [`transmute_copy`] intrinsics
+//! allow for the ***unsafe*** and ***unsound*** transmutation between any `T`
+//! and `U`.
+//!
+//! These intrinsics are deeply unsafe. The Rust compiler will accept uses of
+//! these intrinsics even when `T` and `U` do not have well-defined layouts.
+//! ***Always use a [safe transmutation](#safe-transmutation) method instead,
+//! if possible.*** If you are unable to use a safe transmutation method,
+//! ***you may be relying on undefined compiler behavior***.
+//!
+//! ### Sound Transmutation
+//! [`unsafe_transmute`]: self::unsafe_transmute
+//!
+//! The [`unsafe_transmute`] function allows for the ***unsafe*** transmutation
+//! between `T` and `U`, when merely transmuting from `T` to `U` will not cause
+//! undefined behavior. For the key rules that govern when `T` is soundly
+//! convertible to `U`, see ***[When is a transmutation sound?][soundness]***.
+//!
+//! This operation is `unsafe`, as it will bypass any user-defined validity
+//! restrictions that `U` places on its fields and enforces with its
+//! constructors and methods.
+//!
+//! ***Always use a [safe transmutation](#safe-transmutation) method instead, if
+//! possible.*** If you are unable to use a safe transmutation method, you may
+//! be violating library invariants.
+//!
+//! ### Safe Transmutation
+//! [safe transmutation]: #safe-transmutation
+//! [`TransmuteInto<U>`]: self::TransmuteInto
+//!
+//! The [`TransmuteInto<U>`] trait is implemented for a type `T` if:
+//! 1. [`T` is ***soundly*** transmutable into `U`][soundness], and
+//! 2. [`T` is ***safely*** transmutable into `U`][safety].
+//!
+//! If you are unable to use [`TransmuteInto<U>`], you may be attempting a
+//! transmutation that is relying unspecified behavior.
+
+pub mod safe_transmutation;
+pub mod unsafe_transmutation;
+
+#[doc(inline)]
+pub use crate::private::transmute::{
+    safe_transmute,
+    StableTransmuteInto,
+    TransmuteFrom,
+    TransmuteInto,
+    neglect::TransmuteOptions,
+
+    unsafe_transmute,
+    UnsafeTransmuteFrom,
+    UnsafeTransmuteInto,
+    neglect::UnsafeTransmuteOptions,
+};
+
+/// What static checks should Typic neglect?
+pub mod neglect {
+    #[doc(inline)]
+    pub use crate::private::transmute::neglect::{
+        Alignment,
+        Stability,
+        Transparency,
+    };
+}

--- a/typic/src/transmute.rs
+++ b/typic/src/transmute.rs
@@ -1,7 +1,7 @@
 //! Traits for safe and sound transmutation.
 //!
-//! [soundness]: crate::sound#when-is-a-transmutation-sound
-//! [safety]: crate::safe
+//! [soundness]: crate::transmute::unsafe_transmutation#when-is-a-transmutation-sound
+//! [safety]: crate::transmute::safe_transmutation
 //!
 //! ## Three Types of Transmutation
 //!

--- a/typic/src/transmute/safe_transmutation.rs
+++ b/typic/src/transmute/safe_transmutation.rs
@@ -1,0 +1,127 @@
+//! Guidance and tools for ***safe*** transmutation.
+//!
+//! A [sound transmutation] is safe only if the resulting value cannot possibly
+//! violate library-enforced invariants. Typic assumes that all non-zero-sized
+//! fields with any visibility besides `pub` could have library-enforced
+//! invariants.
+//!
+//! [sound transmutation]: crate#sound-transmutation
+//! [soundness]: crate::sound#when-is-a-transmutation-sound
+//! [`TransmuteInto`]: crate::TransmuteInto
+//! [`unsafe_transmute`]: crate::unsafe_transmute
+//!
+//! ## Why is safety different than soundness?
+//! Consider the type `Constrained`, which enforces a validity constraint on its
+//! fields, and the type `Unconstrained` (which has no internal validity
+//! constraints):
+//!
+//! ```
+//! # use typic::docs::prelude::*;
+//! #[typic::repr(C)]
+//! #[derive(StableABI)]
+//! pub struct Constrained {
+//!     wizz: i8,
+//!     bang: u8,
+//! }
+//!
+//! impl Constrained {
+//!     /// the sum of `wizz` and `bang` must be greater than or equal to zero.
+//!     pub fn new(wizz: i8, bang: u8) -> Self {
+//!         assert!((wizz as i16) / (bang as i16) >= 0);
+//!         Constrained { wizz, bang }
+//!     }
+//!
+//!     pub fn something_dangerous(&self) {
+//!         unsafe {
+//!             // do something that's only safe if `wizz + bang >= 0`
+//!         }
+//!     }
+//! }
+//!
+//! #[typic::repr(C)]
+//! #[derive(StableABI)]
+//! pub struct Unconstrained {
+//!     pub wizz: u8,
+//!     pub bang: i8,
+//! }
+//! ```
+//!
+//! It is [sound][soundness] to transmute an instance of `Unconstrained` into
+//! `Constrained`:
+//! ```
+//! use typic::docs::prelude::*;
+//! use typic::transmute::neglect;
+//! let _ : Constrained  = unsafe { unsafe_transmute::<_, _, neglect::Transparency>(Unconstrained::default()) };
+//! ```
+//! ...but it is **not** safe! The [`unsafe_transmute`] function creates an
+//! instance of `Bar` _without_ calling its `new` constructor, thereby bypassing
+//! the safety check which ensures `something_dangerous` does not violate Rust's
+//! memory model. The compiler will reject our program if we try to safely
+//! transmute `Unconstrained` to `Constrained`:
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! let unconstrained = Unconstrained::default();
+//! let _ : Constrained  = unconstrained.transmute_into();
+//! ```
+//!
+//! Or, ***automatically***, by marking the fields `pub`:
+//! ```
+//! # use typic::docs::prelude::*;
+//! #[typic::repr(C)]
+//! #[derive(StableABI)]
+//! pub struct Unconstrained {
+//!     pub wizz: u8,
+//!     pub bang: i8,
+//! }
+//!
+//! let _ : Unconstrained = u16::default().transmute_into();
+//! ```
+//!
+//! If the fields are marked `pub`, the type cannot possibly rely on any
+//! internal validity requirements, as users of the type are free to manipulate
+//! its fields direclty via the `.` operator.
+//!
+//! ## Safely transmuting references
+//! When safely transmuting owned values, all non-padding bytes in the source
+//! type must correspond to `pub` bytes in the destination type:
+//! ```
+//! # use typic::docs::prelude::*;
+//! let _ : Unconstrained = Constrained::default().transmute_into();
+//! ```
+//! The visibility (or lack thereof) of bytes in the source type does not
+//! affect safety.
+//!
+//! When safely transmuting references, each corresponding byte in the source
+//! and destination types must have the _same_ visibility. Without this
+//! restriction, you could inadvertently violate library invariants of a type
+//! by transmuting and mutating a mutable reference to it:
+//!
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! let mut x = Constrained::default();
+//!
+//! {
+//!     let y : &mut Unconstrained = (&mut x).transmute_into();
+//!                                        // ^^^^^^^^^^^^^^
+//!                                        // Compile Error!
+//!     let z : u8 = -100i8.transmute_into();
+//!     y.wizz = z;
+//! }
+//!
+//! // Ack! `x.wizz + x.bang` is now -100!
+//! // This violates the safety invariant of `something_dangerous`!
+//! x.something_dangerous();
+//! ```
+
+pub use super::{
+    safe_transmute,
+    TransmuteFrom,
+    TransmuteInto,
+    StableTransmuteInto,
+    TransmuteOptions
+};
+
+/// Configuration options for ***safe*** transmutations.
+pub mod neglect {
+    pub use crate::transmute::neglect::Stability;
+}

--- a/typic/src/transmute/safe_transmutation.rs
+++ b/typic/src/transmute/safe_transmutation.rs
@@ -81,6 +81,42 @@
 //! internal validity requirements, as users of the type are free to manipulate
 //! its fields direclty via the `.` operator.
 //!
+//! This rule applies to private fields that are zero-sized. It is
+//! safe to transmute from `Bar` to `Foo`, because `Foo`'s constructor
+//! is `pub`:
+//! ```rust
+//! # use typic::docs::prelude::*;
+//! #[typic::repr(C)]
+//! #[derive(StableABI)]
+//! struct ZST;
+//!
+//! #[typic::repr(C)]
+//! #[derive(StableABI)]
+//! struct Foo(pub ZST);
+//!
+//! #[typic::repr(C)]
+//! #[derive(StableABI)]
+//! struct Bar(ZST);
+//!
+//! let _ : Foo = Bar(ZST).transmute_into();
+//! ```
+//! It is *not* safe to transmute from `Foo` to `Bar`, because `Bar`'s
+//! constructor is not public:
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! # #[typic::repr(C)]
+//! # #[derive(StableABI)]
+//! # struct ZST;
+//! # 
+//! # #[typic::repr(C)]
+//! # #[derive(StableABI)]
+//! # struct Foo(pub ZST);
+//! # 
+//! # #[typic::repr(C)]
+//! # #[derive(StableABI)]
+//! # struct Bar(ZST);
+//! let _ : Bar = Foo(ZST).transmute_into();
+//! ```
 //! ## Safely transmuting references
 //! When safely transmuting owned values, all non-padding bytes in the source
 //! type must correspond to `pub` bytes in the destination type:

--- a/typic/src/transmute/unsafe_transmutation.rs
+++ b/typic/src/transmute/unsafe_transmutation.rs
@@ -65,11 +65,11 @@
 //! ```rust
 //! # use typic::docs::prelude::*;
 //! #[typic::repr(C)]
-//! #[derive(Default)]
+//! #[derive(Default, StableABI)]
 //! struct Padded(pub u8, pub u16, pub u8);
 //!
 //! #[typic::repr(C)]
-//! #[derive(Default)]
+//! #[derive(Default, StableABI)]
 //! struct Packed(pub u16, pub u16, pub u16);
 //!
 //! assert_eq!(mem::size_of::<Packed>(), mem::size_of::<Padded>());

--- a/typic/src/transmute/unsafe_transmutation.rs
+++ b/typic/src/transmute/unsafe_transmutation.rs
@@ -1,0 +1,210 @@
+//! Guidance and tools for ***sound*** transmutation.
+//!
+//! A transmutation is ***sound*** if the mere act of transmutation is
+//! guaranteed to not violate Rust's memory model.
+//!
+//! [`unsafe_transmute`]: crate::unsafe_transmute
+//! [`TransmuteInto<U>`]: crate::TransmuteInto
+//!
+//! ## When is a transmutation sound?
+//! [`NonZeroU8`]: core::num::NonZeroU8
+//!
+//! A transmutation is only sound if it occurs between types with [well-defined
+//! representations](#well-defined-representation), and does not violate Rust's
+//! memory model. See [*Transmutations Between Owned Values*][transmute-owned],
+//! and [*Transmutations Between References*][transmute-references]. These rules
+//! are automatically enforced by [`unsafe_transmute`] and [`TransmuteInto<U>`].
+//!
+//! ### Well-Defined Representation
+//! [`u8`]: core::u8
+//! [`f32`]: core::f32
+//!
+//! Transmutation is ***always unsound*** if it occurs between types with
+//! unspecified representations. Most of Rust's primitive types have specified
+//! representations. That is, the layout characteristics of [`u8`], [`f32`] and
+//! others are guaranteed to be stable across compiler versions.
+//!
+//! In contrast, most `struct` and `enum` types defined without an explicit
+//! `#[repr(C)]` or `#[repr(transparent)]` attribute do ***not*** have
+//! well-specified layout characteristics.
+//!
+//! To ensure that types you've define are soundly transmutable, you usually
+//! must mark them with the `#[repr(C)]` attribute.
+//!
+//! ### Transmuting Owned Values
+//! [transmute-owned]: #transmuting-owned-values
+//!
+//! Transmutations involving owned values must adhere to two rules to be sound.
+//! They must:
+//!  * [preserve or broaden the bit validity][owned-validity], and
+//!  * [preserve or shrink the size][owned-size].
+//!
+//! #### Preserve or Broaden Bit Validity
+//! [owned-validity]: #preserve-or-broaden-bit-validity
+//!
+//! For each _i<sup>th</sup>_ of the destination type, all possible
+//! instantiations of the _i<sup>th</sup>_ byte of the source type must be a
+//! bit-valid instance of the _i<sup>th</sup>_ byte of the destination type.
+//!
+//! For example, we are permitted us to transmute a [`NonZeroU8`] into a [`u8`]:
+//! ```rust
+//! # use typic::docs::prelude::*;
+//! let _ : u8 = NonZeroU8::new(1).unwrap().transmute_into();
+//! ```
+//! ...because all possible instances of [`NonZeroU8`] are also valid instances
+//! of [`u8`]. However, transmuting a [`u8`] into a [`NonZeroU8`] is forbidden:
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! let _ : NonZeroU8 = u8::default().transmute_into(); // Compile Error!
+//! ```
+//! ...because not all instances of [`u8`] are valid instances of [`NonZeroU8`].
+//!
+//! Another example: While laying out certain types, rust may insert padding
+//! bytes between the layouts of fields. In the below example `Padded` has two
+//! padding bytes, while `Packed` has none:
+//! ```rust
+//! # use typic::docs::prelude::*;
+//! #[typic::repr(C)]
+//! #[derive(Default)]
+//! struct Padded(pub u8, pub u16, pub u8);
+//!
+//! #[typic::repr(C)]
+//! #[derive(Default)]
+//! struct Packed(pub u16, pub u16, pub u16);
+//!
+//! assert_eq!(mem::size_of::<Packed>(), mem::size_of::<Padded>());
+//! ```
+//!
+//! We may safely transmute from `Packed` to `Padded`:
+//! ```rust
+//! # use typic::docs::prelude::*;
+//! let _ : Padded = Packed::default().transmute_into();
+//! ```
+//! ...but not from `Padded` to `Packed`:
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! let _ : Packed = Padded::default().transmute_into(); // Compile Error!
+//! ```
+//! ...because doing so would expose two uninitialized padding bytes in `Padded`
+//! as if they were initialized bytes in `Packed`.
+//!
+//! #### Preserve or Shrink Size
+//! [owned-size]: #preserve-or-shrink-size
+//!
+//! It's completely safe to transmute into a type with fewer bytes than the
+//! destination type; e.g.:
+//! ```rust
+//! # use typic::docs::prelude::*;
+//! let _ : u8 = u64::default().transmute_into();
+//! ```
+//! This transmute truncates away the final three bytes of the `u64` value.
+//!
+//! A value may ***not*** be transmuted into a type of greater size:
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! let _ : u64 = u8::default().transmute_into(); // Compile Error!
+//! ```
+//!
+//! ### Transmuting References
+//! [transmute-references]: #transmuting-references
+//!
+//! The [restrictions above that to transmuting owned values][transmute-owned],
+//! also apply to transmuting references. However, references carry a few
+//! additional restrictions. A [sound transmutation](#sound-transmutation) must:
+//!  - [preserve or relax alignment][reference-alignment],
+//!  - [preserve or shrink lifetimes][reference-lifetimes],
+//!  - [preserve or shrink mutability][reference-mutability], and
+//!  - [preserve validity][reference-validity].
+//!
+//! #### Preserve or Relax Alignment
+//! [reference-alignment]: #preserve-or-relax-alignment
+//!
+//! You may transmute a reference into reference of more relaxed alignment:
+//! ```rust
+//! # use typic::docs::prelude::*;
+//! let _: &[u8; 0] = (&[0u16; 0]).transmute_into();
+//! ```
+//!
+//! However, you may **not** transmute a reference into a reference of stricter
+//! alignment:
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! let _: &[u16; 0] = (&[0u8; 0]).transmute_into(); // Compile Error!
+//! ```
+//!
+//! #### Preserve or Shrink Lifetimes
+//! [reference-lifetimes]: #preserve-or-shrink-lifetimes
+//!
+//! You may transmute a reference into reference of lesser lifetime:
+//! ```rust
+//! # use typic::docs::prelude::*;
+//! fn shrink<'a>() -> &'a u8 {
+//!     static long : &'static u8 =  &16;
+//!     long
+//! }
+//! ```
+//!
+//! However, you may **not** transmute a reference into a reference of greater
+//! lifetime:
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! fn extend<'a>(short: &'a u8) -> &'static u8 {
+//!     static long : &'static u8 =  &16;
+//!     short.transmute_into()
+//! }
+//! ```
+//!
+//! #### Preserve or Shrink Mutability
+//! [reference-mutability]: #preserve-or-shrink-mutability
+//!
+//! You may preserve or decrease the mutability of a reference through
+//! transmutation:
+//! ```rust
+//! # use typic::docs::prelude::*;
+//! let _: &u8 = (&42u8).transmute_into();
+//! let _: &u8 = (&mut 42u8).transmute_into();
+//! ```
+//!
+//! However, you may **not** transmute an immutable reference into a mutable
+//! reference:
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! let _: &mut u8 = (&42u8).transmute_into(); // Compile Error!
+//! ```
+//!
+//! #### Preserve Validity
+//! [reference-validity]: #preserve-validity
+//!
+//! Unlike transmutations of owned values, the transmutation of a reference may
+//! also not expand the bit-validity of the referenced type. For instance:
+//!
+//! ```compile_fail
+//! # use typic::docs::prelude::*;
+//! let mut x = NonZeroU8::new(42).unwrap();
+//! {
+//!     let y : &mut u8 = (&mut x).transmute_into(); // Compile Error!
+//!     *y = 0;
+//! }
+//!
+//! let z : NonZeroU8 = x;
+//! ```
+//! If this example did not produce a compile error, the value of `z` would not
+//! be a bit-valid instance of its type.
+
+#[doc(inline)]
+pub use crate::transmute::{
+    unsafe_transmute,
+    UnsafeTransmuteFrom,
+    UnsafeTransmuteInto,
+    UnsafeTransmuteOptions
+};
+
+/// Configuration options for ***sound*** transmutations.
+pub mod neglect {
+    #[doc(inline)]
+    pub use crate::transmute::neglect::{
+        Alignment,
+        Transparency,
+        Stability,
+    };
+}

--- a/typic/tests/transmute.rs
+++ b/typic/tests/transmute.rs
@@ -1,7 +1,7 @@
 use core::mem::align_of;
 use core::num::NonZeroU8;
 use static_assertions::*;
-use typic::{self, transmute::StableTransmuteInto, StableABI};
+use typic::{self, transmute::StableTransmuteInto, stability::StableABI};
 
 #[test]
 fn zst_transmute() {

--- a/typic/tests/transmute.rs
+++ b/typic/tests/transmute.rs
@@ -1,7 +1,7 @@
 use core::mem::align_of;
 use core::num::NonZeroU8;
 use static_assertions::*;
-use typic::{self, StableTransmuteInto, StableABI};
+use typic::{self, transmute::StableTransmuteInto, StableABI};
 
 #[test]
 fn zst_transmute() {

--- a/typic/tests/transmute_stress.rs
+++ b/typic/tests/transmute_stress.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "512"]
 
 use static_assertions::*;
-use typic::{self, StableABI, StableTransmuteInto};
+use typic::{self, StableABI, transmute::StableTransmuteInto};
 
 // Adapted From:
 // https://rust-lang.zulipchat.com/#narrow/stream/216762-project-safe-transmute/topic/typic/near/185459723

--- a/typic/tests/transmute_stress.rs
+++ b/typic/tests/transmute_stress.rs
@@ -1,13 +1,13 @@
 #![recursion_limit = "512"]
 
 use static_assertions::*;
-use typic::{self, TransmuteInto};
+use typic::{self, StableABI, StableTransmuteInto};
 
 // Adapted From:
 // https://rust-lang.zulipchat.com/#narrow/stream/216762-project-safe-transmute/topic/typic/near/185459723
 fn stress() {
     #[typic::repr(C)]
-    #[derive(Default)]
+    #[derive(Default, StableABI)]
     pub struct A(
         pub [u64; 1],
         pub [u64; 2],
@@ -28,7 +28,7 @@ fn stress() {
     );
 
     #[typic::repr(C)]
-    #[derive(Default)]
+    #[derive(Default, StableABI)]
     pub struct B(
         pub [u64; 16],
         pub [u64; 15],

--- a/typic/tests/transmute_stress.rs
+++ b/typic/tests/transmute_stress.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "512"]
 
 use static_assertions::*;
-use typic::{self, StableABI, transmute::StableTransmuteInto};
+use typic::{self, stability::StableABI, transmute::StableTransmuteInto};
 
 // Adapted From:
 // https://rust-lang.zulipchat.com/#narrow/stream/216762-project-safe-transmute/topic/typic/near/185459723


### PR DESCRIPTION
Fixes #3. Transparency is now a property of bytes.

Additionally introduces fine-grained safety & stability parameters so library consumers can opt-in to the particular invariants they don't mind neglecting static guarantees for.