### PR TITLE
soundness link URL update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ let _ : Foo = u32::default().transmute_into(); // Alchemy achieved!
 let _ : u32 = Foo::default().transmute_into(); // Compiler Error!
 ```
 
-[soundness]: https://docs.rs/typic/latest/typic/sound/
+[soundness]: https://docs.rs/typic/latest/typic/transmute/unsafe_transmutation
 [safety]: https://docs.rs/typic/latest/typic/safe/
 
 #### License


### PR DESCRIPTION
the "soundness" link retrieves a lib.rs page saying "The requested resource does not exist ".
I'm not sure if this was the intended link but it looks like it might be relevant discussion.

BTW, Cool stuff!  Could this be valuable in enhancing Rust 64bit application to Rust 32bit Wasm foreign function interface safety for passing zero-copy structs?  If nothing else, it's certainly helping me understand more about memory representation.  Thanks!!!